### PR TITLE
test: fails for default factory

### DIFF
--- a/mashumaro/serializer/base/metaprogramming.py
+++ b/mashumaro/serializer/base/metaprogramming.py
@@ -70,7 +70,9 @@ class CodeBuilder:
     
     @staticmethod
     def __get_default(field):
-        return field.default_factory() if field.default_factory else field.default
+        if not isinstance(field.default_factory, type(MISSING)):
+            return field.default_factory() 
+        return field.default
     
     @property
     def defaults(self):

--- a/mashumaro/serializer/base/metaprogramming.py
+++ b/mashumaro/serializer/base/metaprogramming.py
@@ -67,14 +67,18 @@ class CodeBuilder:
     @property
     def fields(self):
         return self.__get_fields()
-
+    
+    @staticmethod
+    def __get_default(field):
+        return field.default_factory() if field.default_factory else field.default
+    
     @property
     def defaults(self):
         d = {}
         for ancestor in self.cls.__mro__[-1:0:-1]:
             if is_dataclass(ancestor):
                 for field in getattr(ancestor, _FIELDS).values():
-                    d[field.name] = field.default
+                    d[field.name] = self.__get_default(field)
         for name in self.__get_fields(recursive=False):
             d[name] = self.namespace.get(name, MISSING)
         return d

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -4,7 +4,7 @@ import fractions
 import collections
 from enum import Enum
 from datetime import datetime, date, time, timedelta, timezone
-from dataclasses import dataclass, InitVar
+from dataclasses import dataclass, field, InitVar
 from queue import Queue
 from pathlib import Path
 from typing import (
@@ -673,7 +673,12 @@ def test_derived_dataclass_with_ancestors_defaults():
     @dataclass
     class D(C):
         pass
+    
+    @dataclass
+    class E(D, DataClassDictMixin):
+        map: Mapping[str, str] = field(default_factory=dict)
 
     assert B.from_dict({'x': 0}) == B(x=0, y=1, z=3)
     assert C.from_dict({'x': 0}) == C(x=0, y=4, z=3)
     assert D.from_dict({'x': 0}) == D(x=0, y=4, z=3)
+    assert E.from_dict({'x': 0}) == D(x=0, y=4, z=3, map={})


### PR DESCRIPTION
We missed the default factory in previous commits.
Used for mutable data types which are not allowed
to be declared as default arguments