### PR TITLE
Enable use of hooks in superclasses

### DIFF
--- a/mashumaro/serializer/base/dict.py
+++ b/mashumaro/serializer/base/dict.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Mapping, Type, TypeVar
+from typing import Mapping, Type, TypeVar
 
 from mashumaro.serializer.base.metaprogramming import CodeBuilder
 
@@ -36,20 +36,6 @@ class DataClassDictMixin:
         use_enum: bool = False,
         use_datetime: bool = False,
     ) -> T:
-        ...
-
-    @classmethod
-    def __pre_deserialize__(cls: Type[T], d: Dict[Any, Any]) -> Dict[Any, Any]:
-        ...
-
-    @classmethod
-    def __post_deserialize__(cls: Type[T], obj: T) -> T:
-        ...
-
-    def __pre_serialize__(self: T) -> T:
-        ...
-
-    def __post_serialize__(self: T, d: Dict[Any, Any]) -> Dict[Any, Any]:
         ...
 
 

--- a/mashumaro/serializer/base/metaprogramming.py
+++ b/mashumaro/serializer/base/metaprogramming.py
@@ -176,15 +176,8 @@ class CodeBuilder:
             "use_datetime=False):"
         )
         with self.indent():
-            pre_deserialize = self.namespace.get(__PRE_DESERIALIZE__)
-            if pre_deserialize:
-                if not isinstance(pre_deserialize, classmethod):
-                    raise BadHookSignature(
-                        f"`{__PRE_DESERIALIZE__}` must be a class method with "
-                        f"Callable[[Dict[Any, Any]], Dict[Any, Any]] signature"
-                    )
-                else:
-                    self.add_line(f"d = cls.{__PRE_DESERIALIZE__}(d)")
+            if callable(getattr(self.cls, __PRE_DESERIALIZE__, None)):
+                self.add_line(f"d = cls.{__PRE_DESERIALIZE__}(d)")
             self.add_line("try:")
             with self.indent():
                 self.add_line("kwargs = {}")
@@ -273,18 +266,10 @@ class CodeBuilder:
                 self.add_line("else:")
                 with self.indent():
                     self.add_line("raise")
-            post_deserialize = self.namespace.get(__POST_DESERIALIZE__)
-            if post_deserialize:
-                if not isinstance(post_deserialize, classmethod):
-                    raise BadHookSignature(
-                        f"`{__POST_DESERIALIZE__}` must be a class method "
-                        f"with Callable[[{type_name(self.cls)}], "
-                        f"{type_name(self.cls)}] signature"
-                    )
-                else:
-                    self.add_line(
-                        f"return cls.{__POST_DESERIALIZE__}(cls(**kwargs))"
-                    )
+            if callable(getattr(self.cls, __POST_DESERIALIZE__, None)):
+                self.add_line(
+                    f"return cls.{__POST_DESERIALIZE__}(cls(**kwargs))"
+                )
             else:
                 self.add_line("return cls(**kwargs)")
         self.add_line("setattr(cls, 'from_dict', from_dict)")
@@ -298,8 +283,7 @@ class CodeBuilder:
             "use_datetime=False):"
         )
         with self.indent():
-            pre_serialize = self.namespace.get(__PRE_SERIALIZE__)
-            if pre_serialize:
+            if callable(getattr(self.cls, __PRE_SERIALIZE__, None)):
                 self.add_line(f"self = self.{__PRE_SERIALIZE__}()")
             self.add_line("kwargs = {}")
             for fname, ftype in self.field_types.items():
@@ -317,8 +301,7 @@ class CodeBuilder:
                         metadata=metadata,
                     )
                     self.add_line(f"kwargs['{fname}'] = {packed_value}")
-            post_serialize = self.namespace.get(__POST_SERIALIZE__)
-            if post_serialize:
+            if callable(getattr(self.cls, __POST_SERIALIZE__, None)):
                 self.add_line(f"return self.{__POST_SERIALIZE__}(kwargs)")
             else:
                 self.add_line("return kwargs")

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -863,7 +863,7 @@ def test_invalid_field_value_deserialization_with_rounded_decimal():
         DataClass.from_dict({"x": "bad_value"})
 
 
-def test_invalid_field_value_deserialization_with_rounded_decimal_with_default():
+def test_invalid_field_value_deser_with_rounded_decimal_with_default():
     @dataclass
     class DataClass(DataClassDictMixin):
         x: RoundedDecimal() = Fixture.DECIMAL

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -47,7 +47,3 @@ def test_no_code_builder():
 
         assert DataClass.from_dict({}) is None
         assert DataClass().to_dict() is None
-        assert DataClass.__pre_deserialize__({}) is None
-        assert DataClass.__post_deserialize__(DataClass()) is None
-        assert DataClass().__pre_serialize__() is None
-        assert DataClass().__post_serialize__({}) is None


### PR DESCRIPTION
Our project implements common functionality in a mixin class that we include in hundreds of classes. We need to be able to supply hooks in our mixin class that work in the subclassses. The __dict__ attribute that is used to find the callouts does not find superclass methods.