### PR TITLE
Add support for MyEnum(str, Enum)

### DIFF
--- a/mashumaro/serializer/base/metaprogramming.py
+++ b/mashumaro/serializer/base/metaprogramming.py
@@ -386,7 +386,9 @@ class CodeBuilder:
                 raise UnserializableDataError(
                     f"{ftype} as a field type is not supported by mashumaro"
                 )
-        elif issubclass(origin_type, typing.Collection):
+        elif issubclass(origin_type, typing.Collection) and not issubclass(
+            origin_type, enum.Enum
+        ):
             args = getattr(ftype, "__args__", ())
 
             def inner_expr(arg_num=0, v_name="value"):
@@ -567,7 +569,9 @@ class CodeBuilder:
                 raise UnserializableDataError(
                     f"{ftype} as a field type is not supported by mashumaro"
                 )
-        elif issubclass(origin_type, typing.Collection):
+        elif issubclass(origin_type, typing.Collection) and not issubclass(
+            origin_type, enum.Enum
+        ):
             args = getattr(ftype, "__args__", ())
 
             def inner_expr(arg_num=0, v_name="value"):

--- a/tests/entities.py
+++ b/tests/entities.py
@@ -11,6 +11,11 @@ class MyEnum(Enum):
     b = "letter b"
 
 
+class MyStrEnum(str, Enum):
+    a = "letter a"
+    b = "letter b"
+
+
 class MyIntEnum(IntEnum):
     a = 1
     b = 2

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -60,6 +60,7 @@ from .entities import (
     MyFlag,
     MyIntEnum,
     MyIntFlag,
+    MyStrEnum,
 )
 from .utils import same_types
 
@@ -84,6 +85,7 @@ class Fixture:
     STR = "123"
     ENUM = MyEnum.a
     INT_ENUM = MyIntEnum.a
+    STR_ENUM = MyStrEnum.a
     FLAG = MyFlag.a
     INT_FLAG = MyIntFlag.a
     DATA_CLASS = MyDataClass(a=1, b=2)
@@ -136,6 +138,7 @@ inner_values = [
     (bytearray, Fixture.BYTE_ARRAY, Fixture.BYTE_ARRAY),
     (str, Fixture.STR, Fixture.STR),
     (MyEnum, Fixture.ENUM, Fixture.ENUM),
+    (MyStrEnum, Fixture.STR_ENUM, Fixture.STR_ENUM),
     (MyIntEnum, Fixture.INT_ENUM, Fixture.INT_ENUM),
     (MyFlag, Fixture.FLAG, Fixture.FLAG),
     (MyIntFlag, Fixture.INT_FLAG, Fixture.INT_FLAG),


### PR DESCRIPTION
This fixes a bug with custom enums which also inherit from `str`.
```python
class MyStrEnum(str, Enum):
    a = "letter a"
    b = "letter b"
```
They where handled as `str` instead of `Enum` because the `issubclass(origin_type, typing.Collection)` happens before the `Enum` check.

I known it looks a bit strange but `MyEnum(str, Enum)` is useful in f-strings or in combination with the default `json.dumps`.

P.S. The formatting that black forces for the if conditions is not the most readable in my opinion. I would prefer something like this:
```python
elif issubclass(origin_type, typing.Collection) \
    and not issubclass(origin_type, enum.Enum):
```