### PR TITLE
Allow using metadata options for external non-serializable classes

### DIFF
--- a/mashumaro/meta/helpers.py
+++ b/mashumaro/meta/helpers.py
@@ -29,7 +29,7 @@ def type_name(t):
         return str(t)
     else:
         try:
-            return f"{t.__module__}.{t.__qualname__}"
+            return f"{t.__module__}.{t.__name__}"
         except AttributeError:
             return str(t)
 

--- a/tests/test_metadata_options.py
+++ b/tests/test_metadata_options.py
@@ -244,3 +244,24 @@ def test_third_party_type_overridden():
     instance = DataClass.from_dict({"x": "abc"})
     assert instance == should_be
     assert instance.to_dict() == {"x": "abc"}
+
+
+def test_non_serializable_class_options():
+    @dataclass
+    class DataClassA:
+        name: str
+        unique_id: int
+
+    @dataclass
+    class DataClassB(DataClassDictMixin):
+        objA: DataClassA = field(
+            metadata={"serialize": lambda v: None, "deserialize": lambda v: None}
+        )
+        name: str
+    instance = DataClassB(name="testing", objA={"name": "testingA", "unique_id" :123})
+    assert instance
+    should_be = {"name": "testing", "objA": None}
+    assert instance.to_dict() == should_be
+    dct = {"name": "testing", "objA": {"name": "testingA", "unique_id": 123}}
+    instance = DataClassB.from_dict(dct)
+    assert instance.objA is None


### PR DESCRIPTION
The '__qualname__' in the 'type_name' function in mashumaro/meta/helpers.py doesn't work with plain external classes that use metadata for serialization. Test case adde d.