### PR TITLE
Move issubclass calls to avoid python 3.6 bug

### DIFF
--- a/mashumaro/serializer/base/metaprogramming.py
+++ b/mashumaro/serializer/base/metaprogramming.py
@@ -412,6 +412,9 @@ class CodeBuilder:
                 raise UnserializableDataError(
                     f"{ftype} as a field type is not supported by mashumaro"
                 )
+        # put before typing.Collection because of py36 bug
+        elif origin_type in (bool, NoneType):
+            return overridden or value_name
         elif issubclass(origin_type, typing.Collection) and not issubclass(
             origin_type, enum.Enum
         ):
@@ -470,6 +473,9 @@ class CodeBuilder:
                             f"for key,value in m.items()}} "
                             f"for m in value.maps]"
                         )
+            # put before typing.Mapping because of py36 bug
+            elif issubclass(origin_type, str):
+                return overridden or value_name
             elif issubclass(origin_type, typing.Mapping):
                 if ftype is dict:
                     raise UnserializableField(
@@ -495,8 +501,6 @@ class CodeBuilder:
                 return (
                     f"{value_name} if use_bytes else {overridden or specific}"
                 )
-            elif issubclass(origin_type, str):
-                return overridden or value_name
             elif issubclass(origin_type, typing.Sequence):
                 if is_generic(ftype):
                     return (
@@ -512,8 +516,6 @@ class CodeBuilder:
             return overridden or f"int({value_name})"
         elif origin_type is float:
             return overridden or f"float({value_name})"
-        elif origin_type in (bool, NoneType):
-            return overridden or value_name
         elif origin_type in (datetime.datetime, datetime.date, datetime.time):
             if overridden:
                 return f"{value_name} if use_datetime else {overridden}"
@@ -604,6 +606,9 @@ class CodeBuilder:
                 raise UnserializableDataError(
                     f"{ftype} as a field type is not supported by mashumaro"
                 )
+        # put before typing.Collection because of py36 bug
+        elif origin_type in (bool, NoneType):
+            return overridden or value_name
         elif issubclass(origin_type, typing.Collection) and not issubclass(
             origin_type, enum.Enum
         ):
@@ -688,6 +693,9 @@ class CodeBuilder:
                             f"for key, value in m.items()}} "
                             f"for m in {value_name}])"
                         )
+            # put before typing.Mapping because of py36 bug
+            elif issubclass(origin_type, str):
+                return overridden or value_name
             elif issubclass(origin_type, typing.Mapping):
                 if ftype is dict:
                     raise UnserializableField(
@@ -726,8 +734,6 @@ class CodeBuilder:
                         f"decodebytes({value_name}.encode()))"
                     )
                     return overridden or specific
-            elif issubclass(origin_type, str):
-                return overridden or value_name
             elif issubclass(origin_type, typing.Sequence):
                 if is_generic(ftype):
                     return (
@@ -760,8 +766,6 @@ class CodeBuilder:
             return overridden or f"int({value_name})"
         elif origin_type is float:
             return overridden or f"float({value_name})"
-        elif origin_type in (bool, NoneType):
-            return overridden or value_name
         elif origin_type in (datetime.datetime, datetime.date, datetime.time):
             if overridden:
                 return f"{value_name} if use_datetime else {overridden}"

--- a/tests/test_mutable_mapping.py
+++ b/tests/test_mutable_mapping.py
@@ -1,0 +1,59 @@
+from dataclasses import Field, dataclass, field, fields
+from typing import Any, Callable, Dict, MutableMapping
+
+from mashumaro import DataClassDictMixin
+
+
+# dataclass that inherits from MutableMapping
+@dataclass
+class BaseConfig(DataClassDictMixin, MutableMapping[str, Any]):
+    __test__ = False
+    _extra: Dict[str, Any] = field(default_factory=dict)
+
+    def __getitem__(self, key):
+        if hasattr(self, key):
+            return getattr(self, key)
+        else:
+            return self._extra[key]
+
+    def __setitem__(self, key, value):
+        if hasattr(self, key):
+            setattr(self, key, value)
+        else:
+            self._extra[key] = value
+
+    def _content_iterator(self, include_condition: Callable[[Field], bool]):
+        seen = set()
+        for fld in fields(self):
+            seen.add(fld.name)
+            if include_condition(fld):
+                yield fld.name
+        for key in self._extra:
+            if key not in seen:
+                seen.add(key)
+                yield key
+
+    def __delitem__(self, key):
+        if hasattr(self, key):
+            raise Exception("Cannot delete built-inkeys")
+        else:
+            del self._extra[key]
+
+    def __iter__(self):
+        yield from self._content_iterator(include_condition=lambda f: True)
+
+    def __len__(self):
+        return len(fields(self)) + len(self._extra)
+
+
+@dataclass
+class TestConfig(BaseConfig):
+    name: str = "test"
+
+
+def test_mm():
+    obj = TestConfig()
+    assert obj
+
+    dct = obj.to_dict()
+    assert dct


### PR DESCRIPTION
This fixes a bug which we've only seen in Python 3.6. It also appears to be a Heisenbug, since when I tried to put the test case in tests/test_data_type.py it stopped failing. The import from .entities caused the bug to stop happening, which doesn't make much sense. 