### PR TITLE
implement _serializable_encoders dictionary

### DIFF
--- a/mashumaro/serializer/base/dict.py
+++ b/mashumaro/serializer/base/dict.py
@@ -1,11 +1,14 @@
-from typing import Any, Dict, Mapping, Type, TypeVar
+from typing import Any, ClassVar, Dict, Mapping, Type, TypeVar
 
 from mashumaro.serializer.base.metaprogramming import CodeBuilder
+from mashumaro.types import SerializableEncoder
 
 T = TypeVar("T", bound="DataClassDictMixin")
 
 
 class DataClassDictMixin:
+    _serializable_encoders: ClassVar[Dict[Type, SerializableEncoder]] = {}
+
     def __init_subclass__(cls: Type[T], **kwargs):
         builder = CodeBuilder(cls)
         exc = None

--- a/mashumaro/serializer/base/metaprogramming.py
+++ b/mashumaro/serializer/base/metaprogramming.py
@@ -384,6 +384,11 @@ class CodeBuilder:
                 f"self.__dataclass_fields__['{fname}'].type"
                 f"._serialize({value_name})"
             )
+        if type_name(ftype) in self.cls._serializable_encoders:
+            return (
+                f"self._serializable_encoders['{type_name(ftype)}']"
+                f"._serialize({value_name})"
+            )
 
         origin_type = get_type_origin(ftype)
         if is_special_typing_primitive(origin_type):
@@ -619,6 +624,11 @@ class CodeBuilder:
             return overridden or (
                 f"cls.__dataclass_fields__['{fname}'].type"
                 f"._deserialize({value_name})"
+            )
+        if type_name(ftype) in self.cls._serializable_encoders:
+            return (
+                f"cls._serializable_encoders['{type_name(ftype)}']"
+                "._deserialize({value_name})"
             )
 
         origin_type = get_type_origin(ftype)

--- a/mashumaro/types.py
+++ b/mashumaro/types.py
@@ -1,4 +1,17 @@
 import decimal
+from typing import Generic, TypeVar
+
+TV = TypeVar("TV")
+
+
+class SerializableEncoder(Generic[TV]):
+    @classmethod
+    def _serialize(cls, value):
+        raise NotImplementedError
+
+    @classmethod
+    def _deserialize(cls, value):
+        raise NotImplementedError
 
 
 class SerializableType:

--- a/tests/test_encoder_dict.py
+++ b/tests/test_encoder_dict.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import ClassVar, Dict, cast
+
+from dateutil.parser import parse
+
+from mashumaro import DataClassDictMixin
+from mashumaro.types import SerializableEncoder
+
+
+class DateTimeSerializableEncoder(SerializableEncoder[datetime]):
+    @classmethod
+    def _serialize(cls, value: datetime) -> str:
+        out = value.isoformat()
+        if value.tzinfo is None:
+            out = out + "Z"
+        return out
+
+    @classmethod
+    def _deserialize(cls, value: str) -> datetime:
+        return (
+            value if isinstance(value, datetime) else parse(cast(str, value))
+        )
+
+
+class MyDataClassDictMixin(DataClassDictMixin):
+    _serializable_encoders: ClassVar[Dict[str, SerializableEncoder]] = {
+        "datetime.datetime": DateTimeSerializableEncoder(),
+    }
+
+
+def test_ciso8601_datetime_parser():
+    @dataclass
+    class DataClass(MyDataClassDictMixin):
+        generated_at: datetime
+
+    dtnow = datetime.utcnow()
+    instance = DataClass(generated_at=dtnow)
+    assert instance
+    dct = instance.to_dict()
+    assert dct["generated_at"] == dtnow.isoformat() + "Z"


### PR DESCRIPTION
This pull request creates a dictionary of types to encoding classes which provides project wide encoding/decoding for particular types. We use this for our datetime fields.

I know that there are several other ways of providing serializers, but we have a lot of datetime fields and it would take a lot of code changes to implement serializers, whether by using the metadata options or by changing all the datetime classes to a SerializableType. This is a way of providing a standard encoder which doesn't require modifying our existing code. This is based on our previous serialization library (our fork of https://github.com/s-knibbs/dataclasses-jsonschema). 