### PR TITLE
Allow mypy to load typing information from mashumaro

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     author_email="random.gauss@gmail.com",
     url="https://github.com/Fatal1ty/mashumaro",
     packages=find_packages(include=("mashumaro", "mashumaro.*")),
+    package_data={"mashumaro": ["py.typed"]},
     python_requires=">=3.6",
     install_requires=[
         "dataclasses;python_version=='3.6'",
@@ -32,4 +33,5 @@ setup(
         "backports-datetime-fromisoformat;python_version=='3.6'",
         "typing_extensions",
     ],
+    zip_safe=False,
 )


### PR DESCRIPTION
I get this when I run mypy against my codebase using mashumaro:

```
foo.py:9: error: Skipping analyzing 'mashumaro': found module but no type hints or library stubs
foo.py:9: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
foo.py:10: error: Skipping analyzing 'mashumaro.config': found module but no type hints or library stubs
```

But mashumaro does in fact have type hints. This PR tells mypy to load them. 

Further reading:
* https://github.com/encode/httpx/issues/193
* https://mypy.readthedocs.io/en/latest/installed_packages.html#creating-pep-561-compatible-packages