### PR TITLE
Support for aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,11 +725,11 @@ Model(x=Inner(), a=1).to_dict(omit_none=True)  # {'x': {'x': None}, 'a': 1}
 
 #### Add `by_alias` keyword argument
 
-If you want to have control over whether to serialize fields by alias you can
-add `by_alias` parameter to `to_dict` method using the
-`code_generation_options` list. On the other hand if serialization by alias is
-always needed, the best solution is to use the [`serialize_by_alias`](#serialize_by_alias-config-option)
-config option.
+If you want to have control over whether to serialize fields by
+[alias](#alias-option) you can add `by_alias` parameter to `to_dict` method
+using the `code_generation_options` list. On the other hand if serialization
+by alias is always needed, the best solution is to use the
+[`serialize_by_alias`](#serialize_by_alias-config-option) config option.
 
 ```python
 from dataclasses import dataclass, field

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Table of contents
         * [`serialize_by_alias` config option](#serialize_by_alias-config-option)
     * [Code generation options](#config-options)
         * [Add `omit_none` keyword argument](#add-omit_none-keyword-argument)
-        * [Add `by_alias` keyword argument](#add-by-alias-keyword-argument)
+        * [Add `by_alias` keyword argument](#add-by_alias-keyword-argument)
     * [Serialization hooks](#serialization-hooks)
         * [Before deserialization](#before-deserialization)
         * [After deserialization](#after-deserialization)
@@ -597,7 +597,7 @@ described below.
 | Constant                                                        | Description
 |:--------------------------------------------------------------- |:------------------------------------------------------------|
 | [`TO_DICT_ADD_OMIT_NONE_FLAG`](#add-omit_none-keyword-argument) | Adds `omit_none` keyword-only argument to `to_dict` method. |
-| [`TO_DICT_ADD_BY_ALIAS_FLAG`](#add-omit_none-keyword-argument)  | Adds `by_alias` keyword-only arguments to `to_dict` method. |
+| [`TO_DICT_ADD_BY_ALIAS_FLAG`](#add-by_alias-keyword-argument)   | Adds `by_alias` keyword-only arguments to `to_dict` method. |
 
 #### `serialization_strategy` config option
 
@@ -649,8 +649,8 @@ dictionary = instance.to_dict()
 
 #### `serialize_by_alias` config option
 
-If you want to serialize all the fields by its aliases, this option enables this.
-You may also consider a more flexible but less fast [`by_alias`](#add-by-alias-keyword-argument) keyword argument.
+All the fields with aliases will be serialized by them when this option is enabled.
+The more flexible but less fast way to do the same is using [`by_alias`](#add-by_alias-keyword-argument) keyword argument.
 
 ```python
 from dataclasses import dataclass, field

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Table of contents
         * [`debug` config option](#debug-config-option)
         * [`code_generation_options` config option](#code_generation_options-config-option)
         * [`serialization_strategy` config option](#serialization_strategy-config-option)
+        * [`aliases` config option](#aliases-config-option)
         * [`serialize_by_alias` config option](#serialize_by_alias-config-option)
     * [Code generation options](#config-options)
         * [Add `omit_none` keyword argument](#add-omit_none-keyword-argument)
@@ -541,6 +542,9 @@ x = DataClass.from_dict({"FieldA": 1, "#invalid": 2})  # DataClass(a=1, b=2)
 x.to_dict()  # {"a": 1, "b": 2}  # no aliases on serialization by default
 ```
 
+If you want to write all the field aliases in one place there is
+[such a config option](#aliases-config-option).
+
 If you want to serialize all the fields by aliases you have two options to do so:
 * [`serialize_by_alias` config option](#serialize_by_alias-config-option)
 * [`by_alias` keyword argument in `to_dict` method](#add-by_alias-keyword-argument)
@@ -670,6 +674,31 @@ instance = DataClass.from_dict({"datetime": "2021", "date": "2021"})
 # DataClass(datetime=datetime.datetime(2021, 1, 1, 0, 0), date=Date(2021, 1, 1))
 dictionary = instance.to_dict()
 # {'datetime': '2021', 'date': '2021-01-01'}
+```
+
+#### `aliases` config option
+
+Sometimes it's better to write the field aliases in one place. You can mix
+aliases here with [aliases in the field options](#alias-option), but the last ones will always
+take precedence.
+
+```python
+from dataclasses import dataclass
+from mashumaro import DataClassDictMixin
+from mashumaro.config import BaseConfig
+
+@dataclass
+class DataClass(DataClassDictMixin):
+    field_a: int
+    field_b: int
+
+    class Config(BaseConfig):
+        aliases = {
+            "field_a": "FieldA",
+            "field_b": "FieldB",
+        }
+
+DataClass.from_dict({"FieldA": 1, "FieldB": 2})  # DataClass(a=1, b=2)
 ```
 
 #### `serialize_by_alias` config option

--- a/README.md
+++ b/README.md
@@ -725,8 +725,8 @@ Model(x=Inner(), a=1).to_dict(omit_none=True)  # {'x': {'x': None}, 'a': 1}
 
 #### Add `by_alias` keyword argument
 
-If you want to have control over whether to serialize fields by
-[alias](#alias-option) you can add `by_alias` parameter to `to_dict` method
+If you want to have control over whether to serialize fields by their
+[aliases](#alias-option) you can add `by_alias` parameter to `to_dict` method
 using the `code_generation_options` list. On the other hand if serialization
 by alias is always needed, the best solution is to use the
 [`serialize_by_alias`](#serialize_by_alias-config-option) config option.

--- a/README.md
+++ b/README.md
@@ -748,7 +748,7 @@ DataClass(field_a=1).to_dict(by_alias=True)  # {'FieldA': 1}
 ```
 
 Keep in mind, if you're serializing data in JSON or another format, then you
-need to pass "by_alias" argument to [`dict_params`](#dataclassjsonmixinto_jsonencoder-optionalencoder-dict_params-optionalmapping-encoder_kwargs) dictionary.
+need to pass `by_alias` argument to [`dict_params`](#dataclassjsonmixinto_jsonencoder-optionalencoder-dict_params-optionalmapping-encoder_kwargs) dictionary.
 
 ### Serialization hooks
 

--- a/README.md
+++ b/README.md
@@ -649,7 +649,7 @@ dictionary = instance.to_dict()
 
 #### `serialize_by_alias` config option
 
-All the fields with aliases will be serialized by them when this option is enabled.
+All the fields with [aliases](#alias-option) will be serialized by them when this option is enabled.
 The more flexible but less fast way to do the same is using [`by_alias`](#add-by_alias-keyword-argument) keyword argument.
 
 ```python

--- a/mashumaro/config.py
+++ b/mashumaro/config.py
@@ -15,4 +15,5 @@ class BaseConfig:
     debug: bool = False
     code_generation_options: List[str] = []
     serialization_strategy: Dict[Any, SerializationStrategyValueType] = {}
+    aliases: Dict[str, str] = {}
     serialize_by_alias: bool = False

--- a/mashumaro/config.py
+++ b/mashumaro/config.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Dict, List, Union
 from mashumaro.types import SerializationStrategy
 
 TO_DICT_ADD_OMIT_NONE_FLAG = "TO_DICT_ADD_OMIT_NONE_FLAG"
+TO_DICT_ADD_BY_ALIAS_FLAG = "TO_DICT_ADD_BY_ALIAS_FLAG"
 
 
 SerializationStrategyValueType = Union[
@@ -14,3 +15,4 @@ class BaseConfig:
     debug: bool = False
     code_generation_options: List[str] = []
     serialization_strategy: Dict[Any, SerializationStrategyValueType] = {}
+    serialize_by_alias: bool = False

--- a/mashumaro/helper.py
+++ b/mashumaro/helper.py
@@ -7,11 +7,13 @@ def field_options(
     serialize: Optional[Callable[[Any], Any]] = None,
     deserialize: Optional[Union[str, Callable[[Any], Any]]] = None,
     serialization_strategy: Optional[SerializationStrategy] = None,
+    alias: Optional[str] = None,
 ):
     return {
         "serialize": serialize,
         "deserialize": deserialize,
         "serialization_strategy": serialization_strategy,
+        "alias": alias,
     }
 
 

--- a/mashumaro/serializer/base/dict.py
+++ b/mashumaro/serializer/base/dict.py
@@ -25,7 +25,10 @@ class DataClassDictMixin:
         use_bytes: bool = False,
         use_enum: bool = False,
         use_datetime: bool = False,
-        # omit_none: bool = False  # exists with the code generation option
+        # *
+        # keyword-only flags that are exist with the code generation options:
+        # omit_none: bool = False
+        # by_alias: bool = False
         **kwargs,
     ) -> dict:
         ...

--- a/mashumaro/serializer/base/metaprogramming.py
+++ b/mashumaro/serializer/base/metaprogramming.py
@@ -329,9 +329,9 @@ class CodeBuilder:
         code_generation_options = config.code_generation_options
         pluggable_flags = []
         if TO_DICT_ADD_OMIT_NONE_FLAG in code_generation_options:
-            pluggable_flags.append("omit_none")
+            pluggable_flags.append("omit_none=omit_none")
         if TO_DICT_ADD_BY_ALIAS_FLAG in code_generation_options:
-            pluggable_flags.append("by_alias")
+            pluggable_flags.append("by_alias=by_alias")
         return ",".join(
             ["use_bytes", "use_enum", "use_datetime", *pluggable_flags]
         )
@@ -351,7 +351,7 @@ class CodeBuilder:
         if by_alias_feature:
             pluggable_flags.append("by_alias")
         if pluggable_flags:
-            pluggable_flags_str = ", " + ", ".join(
+            pluggable_flags_str = ", *, " + ", ".join(
                 [f"{f}=False" for f in pluggable_flags]
             )
         else:

--- a/mashumaro/serializer/base/metaprogramming.py
+++ b/mashumaro/serializer/base/metaprogramming.py
@@ -210,6 +210,7 @@ class CodeBuilder:
 
     def add_from_dict(self) -> None:
 
+        config = self.get_config()
         self.reset()
         self.add_line("@classmethod")
         self.add_line(
@@ -233,6 +234,8 @@ class CodeBuilder:
                     self._add_type_modules(ftype)
                     metadata = self.metadatas.get(fname, {})
                     alias = metadata.get("alias")
+                    if alias is None:
+                        alias = config.aliases.get(fname)
                     self._from_dict_set_value(fname, ftype, metadata, alias)
             self.add_line("except AttributeError:")
             with self.indent():
@@ -392,7 +395,10 @@ class CodeBuilder:
         by_alias_feature = self.is_code_generation_option_enabled(
             TO_DICT_ADD_BY_ALIAS_FLAG
         )
+        config = self.get_config()
         alias = metadata.get("alias")
+        if alias is None:
+            alias = config.aliases.get(fname)
         serialize_by_alias = self.get_config().serialize_by_alias
         if serialize_by_alias and alias is not None:
             fname_or_alias = alias

--- a/mashumaro/serializer/base/metaprogramming.py
+++ b/mashumaro/serializer/base/metaprogramming.py
@@ -13,16 +13,16 @@ import uuid
 # noinspection PyUnresolvedReferences
 from base64 import decodebytes, encodebytes  # noqa
 from contextlib import contextmanager, suppress
-from types import MappingProxyType
 
 # noinspection PyProtectedMember
 from dataclasses import _FIELDS, MISSING, Field, is_dataclass  # type: ignore
 from decimal import Decimal
 from fractions import Fraction
+from types import MappingProxyType
 
 from mashumaro.config import (
-    TO_DICT_ADD_OMIT_NONE_FLAG,
     TO_DICT_ADD_BY_ALIAS_FLAG,
+    TO_DICT_ADD_OMIT_NONE_FLAG,
     BaseConfig,
 )
 

--- a/mashumaro/serializer/base/metaprogramming.py
+++ b/mashumaro/serializer/base/metaprogramming.py
@@ -272,8 +272,7 @@ class CodeBuilder:
             self.add_line("elif value is MISSING:")
             with self.indent():
                 self.add_line(
-                    f"raise MissingField('{fname}',"
-                    f"{type_name(ftype)},cls)"
+                    f"raise MissingField('{fname}'," f"{type_name(ftype)},cls)"
                 )
             self.add_line("else:")
             with self.indent():
@@ -285,9 +284,7 @@ class CodeBuilder:
                 )
                 self.add_line("try:")
                 with self.indent():
-                    self.add_line(
-                        f"kwargs['{fname}'] = {unpacked_value}"
-                    )
+                    self.add_line(f"kwargs['{fname}'] = {unpacked_value}")
                 self.add_line("except Exception as e:")
                 with self.indent():
                     field_type = type_name(ftype)
@@ -409,20 +406,20 @@ class CodeBuilder:
                 self.add_line("if not omit_none:")
                 with self.indent():
                     if by_alias_feature and alias is not None:
-                        self.add_line('if by_alias:')
+                        self.add_line("if by_alias:")
                         with self.indent():
                             self.add_line(f"kwargs['{alias}'] = None")
-                        self.add_line('else:')
+                        self.add_line("else:")
                         with self.indent():
                             self.add_line(f"kwargs['{fname}'] = None")
                     else:
                         self.add_line(f"kwargs['{fname_or_alias}'] = None")
             else:
                 if by_alias_feature and alias is not None:
-                    self.add_line('if by_alias:')
+                    self.add_line("if by_alias:")
                     with self.indent():
                         self.add_line(f"kwargs['{alias}'] = None")
-                    self.add_line('else:')
+                    self.add_line("else:")
                     with self.indent():
                         self.add_line(f"kwargs['{fname}'] = None")
                 else:

--- a/tests/entities.py
+++ b/tests/entities.py
@@ -1,10 +1,14 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum, Flag, IntEnum, IntFlag
 from os import PathLike
 from typing import Optional, Union
 
 from mashumaro import DataClassDictMixin
-from mashumaro.config import TO_DICT_ADD_OMIT_NONE_FLAG, BaseConfig
+from mashumaro.config import (
+    TO_DICT_ADD_BY_ALIAS_FLAG,
+    TO_DICT_ADD_OMIT_NONE_FLAG,
+    BaseConfig,
+)
 from mashumaro.types import SerializableType
 
 
@@ -87,6 +91,19 @@ class MyDataClassWithOptionalAndOmitNoneFlag(DataClassDictMixin):
 
     class Config(BaseConfig):
         code_generation_options = [TO_DICT_ADD_OMIT_NONE_FLAG]
+
+
+@dataclass
+class MyDataClassWithAlias(DataClassDictMixin):
+    a: int = field(metadata={"alias": "alias_a"})
+
+
+@dataclass
+class MyDataClassWithAliasAndSerializeByAliasFlag(DataClassDictMixin):
+    a: int = field(metadata={"alias": "alias_a"})
+
+    class Config(BaseConfig):
+        code_generation_options = [TO_DICT_ADD_BY_ALIAS_FLAG]
 
 
 class ThirdPartyType:

--- a/tests/entities.py
+++ b/tests/entities.py
@@ -1,14 +1,10 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum, Flag, IntEnum, IntFlag
 from os import PathLike
 from typing import Optional, Union
 
 from mashumaro import DataClassDictMixin
-from mashumaro.config import (
-    TO_DICT_ADD_BY_ALIAS_FLAG,
-    TO_DICT_ADD_OMIT_NONE_FLAG,
-    BaseConfig,
-)
+from mashumaro.config import TO_DICT_ADD_OMIT_NONE_FLAG, BaseConfig
 from mashumaro.types import SerializableType
 
 
@@ -91,19 +87,6 @@ class MyDataClassWithOptionalAndOmitNoneFlag(DataClassDictMixin):
 
     class Config(BaseConfig):
         code_generation_options = [TO_DICT_ADD_OMIT_NONE_FLAG]
-
-
-@dataclass
-class MyDataClassWithAlias(DataClassDictMixin):
-    a: int = field(metadata={"alias": "alias_a"})
-
-
-@dataclass
-class MyDataClassWithAliasAndSerializeByAliasFlag(DataClassDictMixin):
-    a: int = field(metadata={"alias": "alias_a"})
-
-    class Config(BaseConfig):
-        code_generation_options = [TO_DICT_ADD_BY_ALIAS_FLAG]
 
 
 class ThirdPartyType:

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -136,3 +136,17 @@ def test_serialize_by_alias_flag_for_inner_class_with_it():
     instance = DataClass(AliasedWithSerializeByAliasFlag(a=1))
     assert instance.to_dict() == {"x": {"a": 1}}
     assert instance.to_dict(by_alias=True) == {"alias_x": {"alias_a": 1}}
+
+
+def test_aliases_in_config():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        a: int = 111
+
+        class Config(BaseConfig):
+            aliases = {"a": "alias_a"}
+            serialize_by_alias = True
+
+    assert DataClass.from_dict({"alias_a": 123}) == DataClass(a=123)
+    assert DataClass.from_dict({}) == DataClass(a=111)
+    assert DataClass(a=123).to_dict() == {"alias_a": 123}

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -1,0 +1,110 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+import pytest
+
+from mashumaro import DataClassDictMixin
+from mashumaro.config import BaseConfig, TO_DICT_ADD_BY_ALIAS_FLAG
+from mashumaro.exceptions import MissingField
+
+
+@dataclass
+class Aliased(DataClassDictMixin):
+    a: int = field(metadata={"alias": "alias_a"})
+
+
+@dataclass
+class AliasedWithDefault(DataClassDictMixin):
+    a: int = field(default=111, metadata={"alias": "alias_a"})
+
+
+@dataclass
+class AliasedWithDefaultNone(DataClassDictMixin):
+    a: Optional[int] = field(default=None, metadata={"alias": "alias_a"})
+
+
+@dataclass
+class AliasedWithSerializeByAliasFlag(DataClassDictMixin):
+    a: int = field(metadata={"alias": "alias_a"})
+
+    class Config(BaseConfig):
+        code_generation_options = [TO_DICT_ADD_BY_ALIAS_FLAG]
+
+
+def test_alias():
+    assert Aliased.from_dict({"alias_a": 123}) == Aliased(a=123)
+    with pytest.raises(MissingField):
+        assert Aliased.from_dict({"a": 123})
+
+
+def test_alias_with_default():
+    assert AliasedWithDefault.from_dict(
+        {"alias_a": 123}
+    ) == AliasedWithDefault(a=123)
+    assert AliasedWithDefault.from_dict({}) == AliasedWithDefault(a=111)
+
+
+def test_serialize_by_alias_code_generation_flag():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: int = field(metadata={"alias": "alias"})
+
+        class Config(BaseConfig):
+            code_generation_options = [TO_DICT_ADD_BY_ALIAS_FLAG]
+
+    instance = DataClass(x=123)
+    assert instance.to_dict() == {"x": 123}
+    assert instance.to_dict(by_alias=True) == {"alias": 123}
+
+
+def test_serialize_by_alias_code_generation_flag_without_alias():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: int
+
+        class Config(BaseConfig):
+            code_generation_options = [TO_DICT_ADD_BY_ALIAS_FLAG]
+
+    instance = DataClass(x=123)
+    assert instance.to_dict() == {"x": 123}
+    assert instance.to_dict(by_alias=True) == {"x": 123}
+
+
+def test_no_serialize_by_alias_code_generation_flag():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: int = field(metadata={"alias": "alias"})
+
+    instance = DataClass(x=123)
+    assert instance.to_dict() == {"x": 123}
+    with pytest.raises(TypeError):
+        instance.to_dict(by_alias=True)
+
+
+def test_serialize_by_alias_flag_for_inner_class_without_it():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: Aliased = field(default=None, metadata={"alias": "alias_x"})
+
+        class Config(BaseConfig):
+            debug = True
+            code_generation_options = [TO_DICT_ADD_BY_ALIAS_FLAG]
+
+    instance = DataClass(Aliased(a=1))
+    assert instance.to_dict() == {"x": {"a": 1}}
+    assert instance.to_dict(by_alias=True) == {"alias_x": {"a": 1}}
+
+
+def test_serialize_by_alias_flag_for_inner_class_with_it():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: AliasedWithSerializeByAliasFlag = field(
+            default=None, metadata={"alias": "alias_x"}
+        )
+
+        class Config(BaseConfig):
+            code_generation_options = [TO_DICT_ADD_BY_ALIAS_FLAG]
+
+    instance = DataClass(AliasedWithSerializeByAliasFlag(a=1))
+    assert instance.to_dict() == {"x": {"a": 1}}
+    assert instance.to_dict(by_alias=True) == {"alias_x": {"alias_a": 1}}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,19 +1,16 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional, Union
 
 import pytest
 
 from mashumaro import DataClassDictMixin
 from mashumaro.config import (
-    TO_DICT_ADD_BY_ALIAS_FLAG,
     TO_DICT_ADD_OMIT_NONE_FLAG,
     BaseConfig,
 )
 from mashumaro.types import SerializationStrategy
 
 from .entities import (
-    MyDataClassWithAlias,
-    MyDataClassWithAliasAndSerializeByAliasFlag,
     MyDataClassWithOptional,
     MyDataClassWithOptionalAndOmitNoneFlag,
 )
@@ -152,58 +149,3 @@ def test_serialization_strategy():
     instance = DataClass(a=123, b="abc")
     assert DataClass.from_dict({"a": [123], "b": ["abc"]}) == instance
     assert instance.to_dict() == {"a": [123], "b": ["abc"]}
-
-
-def test_serialize_by_alias_code_generation_flag():
-    @dataclass
-    class DataClass(DataClassDictMixin):
-        x: int = field(metadata={"alias": "alias"})
-
-        class Config(BaseConfig):
-            code_generation_options = [TO_DICT_ADD_BY_ALIAS_FLAG]
-
-    instance = DataClass(x=123)
-    assert instance.to_dict() == {"x": 123}
-    assert instance.to_dict(by_alias=True) == {"alias": 123}
-
-
-def test_no_serialize_by_alias_code_generation_flag():
-    @dataclass
-    class DataClass(DataClassDictMixin):
-        x: int = field(metadata={"alias": "alias"})
-
-    instance = DataClass(x=123)
-    assert instance.to_dict() == {"x": 123}
-    with pytest.raises(TypeError):
-        instance.to_dict(by_alias=True)
-
-
-def test_serialize_by_alias_flag_for_inner_class_without_it():
-    @dataclass
-    class DataClass(DataClassDictMixin):
-        x: MyDataClassWithAlias = field(
-            default=None, metadata={"alias": "alias_x"}
-        )
-
-        class Config(BaseConfig):
-            debug = True
-            code_generation_options = [TO_DICT_ADD_BY_ALIAS_FLAG]
-
-    instance = DataClass(MyDataClassWithAlias(a=1))
-    assert instance.to_dict() == {"x": {"a": 1}}
-    assert instance.to_dict(by_alias=True) == {"alias_x": {"a": 1}}
-
-
-def test_serialize_by_alias_flag_for_inner_class_with_it():
-    @dataclass
-    class DataClass(DataClassDictMixin):
-        x: MyDataClassWithAliasAndSerializeByAliasFlag = field(
-            default=None, metadata={"alias": "alias_x"}
-        )
-
-        class Config(BaseConfig):
-            code_generation_options = [TO_DICT_ADD_BY_ALIAS_FLAG]
-
-    instance = DataClass(MyDataClassWithAliasAndSerializeByAliasFlag(a=1))
-    assert instance.to_dict() == {"x": {"a": 1}}
-    assert instance.to_dict(by_alias=True) == {"alias_x": {"alias_a": 1}}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,13 +1,19 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional, Union
 
 import pytest
 
 from mashumaro import DataClassDictMixin
-from mashumaro.config import TO_DICT_ADD_OMIT_NONE_FLAG, BaseConfig
+from mashumaro.config import (
+    TO_DICT_ADD_BY_ALIAS_FLAG,
+    TO_DICT_ADD_OMIT_NONE_FLAG,
+    BaseConfig,
+)
 from mashumaro.types import SerializationStrategy
 
 from .entities import (
+    MyDataClassWithAlias,
+    MyDataClassWithAliasAndSerializeByAliasFlag,
     MyDataClassWithOptional,
     MyDataClassWithOptionalAndOmitNoneFlag,
 )
@@ -146,3 +152,58 @@ def test_serialization_strategy():
     instance = DataClass(a=123, b="abc")
     assert DataClass.from_dict({"a": [123], "b": ["abc"]}) == instance
     assert instance.to_dict() == {"a": [123], "b": ["abc"]}
+
+
+def test_serialize_by_alias_code_generation_flag():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: int = field(metadata={"alias": "alias"})
+
+        class Config(BaseConfig):
+            code_generation_options = [TO_DICT_ADD_BY_ALIAS_FLAG]
+
+    instance = DataClass(x=123)
+    assert instance.to_dict() == {"x": 123}
+    assert instance.to_dict(by_alias=True) == {"alias": 123}
+
+
+def test_no_serialize_by_alias_code_generation_flag():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: int = field(metadata={"alias": "alias"})
+
+    instance = DataClass(x=123)
+    assert instance.to_dict() == {"x": 123}
+    with pytest.raises(TypeError):
+        instance.to_dict(by_alias=True)
+
+
+def test_serialize_by_alias_flag_for_inner_class_without_it():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: MyDataClassWithAlias = field(
+            default=None, metadata={"alias": "alias_x"}
+        )
+
+        class Config(BaseConfig):
+            debug = True
+            code_generation_options = [TO_DICT_ADD_BY_ALIAS_FLAG]
+
+    instance = DataClass(MyDataClassWithAlias(a=1))
+    assert instance.to_dict() == {"x": {"a": 1}}
+    assert instance.to_dict(by_alias=True) == {"alias_x": {"a": 1}}
+
+
+def test_serialize_by_alias_flag_for_inner_class_with_it():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: MyDataClassWithAliasAndSerializeByAliasFlag = field(
+            default=None, metadata={"alias": "alias_x"}
+        )
+
+        class Config(BaseConfig):
+            code_generation_options = [TO_DICT_ADD_BY_ALIAS_FLAG]
+
+    instance = DataClass(MyDataClassWithAliasAndSerializeByAliasFlag(a=1))
+    assert instance.to_dict() == {"x": {"a": 1}}
+    assert instance.to_dict(by_alias=True) == {"alias_x": {"alias_a": 1}}

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -7,6 +7,7 @@ def test_field_options_helper():
         "serialize": None,
         "deserialize": None,
         "serialization_strategy": None,
+        "alias": None,
     }
 
     def serialize(x):
@@ -23,13 +24,16 @@ def test_field_options_helper():
             return value
 
     serialization_strategy = TestSerializationStrategy()
+    alias = "alias"
 
     assert field_options(
         serialize=serialize,
         deserialize=deserialize,
         serialization_strategy=serialization_strategy,
+        alias=alias,
     ) == {
         "serialize": serialize,
         "deserialize": deserialize,
         "serialization_strategy": serialization_strategy,
+        "alias": alias,
     }


### PR DESCRIPTION
This pull request adds support for aliases.

The example from https://github.com/Fatal1ty/mashumaro/issues/6 could be written either this way:
```python
from dataclasses import dataclass, field
from mashumaro import DataClassJSONMixin, field_options

@dataclass
class User(DataClassJSONMixin):
    id: int = field(metadata=field_options(alias="ID"))
    name: str = field(metadata=field_options(alias="Name"))
    address_no: str = field(metadata=field_options(alias="Address-No"))


d = {"ID": 13, "Name": "James", "Address-No": "ABC 132"}
print(User.from_dict(d))  # User(id=13, name='James', address_no='ABC 132')
```

or this way:
```python
from dataclasses import dataclass
from mashumaro import DataClassJSONMixin
from mashumaro.config import BaseConfig

@dataclass
class User(DataClassJSONMixin):
    id: int
    name: str
    address_no: str

    class Config(BaseConfig):
        aliases = {
            "id": "ID",
            "name": "Name",
            "address_no": "Address-No",
        }


d = {"ID": 13, "Name": "James", "Address-No": "ABC 132"}
print(User.from_dict(d))  # User(id=13, name='James', address_no='ABC 132')
```

To serialize by alias there is a new `serialize_by_alias` config option and `TO_DICT_ADD_BY_ALIAS_FLAG` code generation flag. 