### PR TITLE
Add slots to [Generic]SerializableType

### DIFF
--- a/mashumaro/types.py
+++ b/mashumaro/types.py
@@ -16,6 +16,8 @@ __all__ = [
 
 
 class SerializableType:
+    __slots__ = ()
+
     __use_annotations__ = False
 
     def __init_subclass__(
@@ -37,6 +39,8 @@ class SerializableType:
 
 
 class GenericSerializableType:
+    __slots__ = ()
+
     def _serialize(self, types: List[Type]) -> Any:
         raise NotImplementedError
 


### PR DESCRIPTION
Hey,

Just realized that SerializableType and GenericSerializableType do not define `__slots__` (unlike `DataClassXXXMixin`) which indirectly makes it impossible to create/use slotted custom types.

Very small change, looks pretty benign to me, but valuable.