### PR TITLE
Add sort keys option for dataclasses inheriting from mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Table of contents
         * [`orjson_options`](#orjson_options-config-option)
         * [`discriminator` config option](#discriminator-config-option)
         * [`lazy_compilation` config option](#lazy_compilation-config-option)
+        * [`sort_keys` config option](#sort_keys-config-option)
     * [Passing field values as is](#passing-field-values-as-is)
     * [Extending existing types](#extending-existing-types)
     * [Dialects](#dialects)
@@ -1364,6 +1365,25 @@ by leveraging the data that is accessible after the class has been created.
 > from_dict = lambda x: MyModel.from_dict(x)
 > to_dict = lambda x: x.to_dict()
 > ```
+
+#### `sort_keys` config option
+
+When set, the keys on serialized dataclasses will be sorted in alphabetical order.
+
+Unlike the `sort_keys` option in the standard library's `json.dumps` function, this option acts at class creation time and has no effect on the performance of serialization.
+
+```python
+@dataclass
+    class SortedDataClass(DataClassDictMixin):
+        foo: int
+        bar: int
+
+        class Config(BaseConfig):
+            sort_keys = True
+
+t = SortedDataClass(1, 2)
+assert t.to_dict() == {"bar": 2, "foo": 1}
+```
 
 ### Passing field values as is
 

--- a/mashumaro/config.py
+++ b/mashumaro/config.py
@@ -48,3 +48,4 @@ class BaseConfig:
     json_schema: Dict[str, Any] = {}
     discriminator: Optional[Discriminator] = None
     lazy_compilation: bool = False
+    sort_keys: bool = False

--- a/mashumaro/core/meta/code/builder.py
+++ b/mashumaro/core/meta/code/builder.py
@@ -870,7 +870,11 @@ class CodeBuilder:
             aliases = {}
             nullable_fields = set()
             nontrivial_nullable_fields = set()
-            for fname, ftype in field_types.items():
+            fnames_and_types = list(field_types.items())
+            if self.get_config().sort_keys:
+                fnames_and_types.sort(key=lambda x: x[0])
+
+            for fname, ftype in fnames_and_types:
                 if self.metadatas.get(fname, {}).get("serialize") == "omit":
                     continue
                 packer, alias, could_be_none = self._get_field_packer(

--- a/mashumaro/core/meta/code/builder.py
+++ b/mashumaro/core/meta/code/builder.py
@@ -870,9 +870,11 @@ class CodeBuilder:
             aliases = {}
             nullable_fields = set()
             nontrivial_nullable_fields = set()
-            fnames_and_types = list(field_types.items())
+            fnames_and_types: typing.Iterable[
+                tuple[str, typing.Any]
+            ] = field_types.items()
             if self.get_config().sort_keys:
-                fnames_and_types.sort(key=lambda x: x[0])
+                fnames_and_types = sorted(fnames_and_types, key=lambda x: x[0])
 
             for fname, ftype in fnames_and_types:
                 if self.metadatas.get(fname, {}).get("serialize") == "omit":

--- a/mashumaro/core/meta/code/builder.py
+++ b/mashumaro/core/meta/code/builder.py
@@ -871,7 +871,7 @@ class CodeBuilder:
             nullable_fields = set()
             nontrivial_nullable_fields = set()
             fnames_and_types: typing.Iterable[
-                tuple[str, typing.Any]
+                typing.Tuple[str, typing.Any]
             ] = field_types.items()
             if self.get_config().sort_keys:
                 fnames_and_types = sorted(fnames_and_types, key=lambda x: x[0])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -244,3 +244,32 @@ def test_lazy_compilation():
     obj = LazyCompilationDataClass(42)
     assert LazyCompilationDataClass.from_dict({"x": "42"}) == obj
     assert obj.to_dict() == {"x": 42}
+
+
+def test_sort_keys():
+    @dataclass
+    class SortedDataClass(DataClassDictMixin):
+        foo: int
+        bar: int
+
+        class Config(BaseConfig):
+            sort_keys = True
+
+    @dataclass
+    class UnSortedDataClass(DataClassDictMixin):
+        foo: int
+        bar: int
+
+        class Config(BaseConfig):
+            sort_keys = False
+
+    t = SortedDataClass(1, 2)
+    assert t.to_dict() == {"bar": 2, "foo": 1}
+    assert (
+        SortedDataClass.from_dict({"bar": 2, "foo": 1})
+        == SortedDataClass.from_dict({"foo": 1, "bar": 2})
+        == t
+    )
+
+    t = UnSortedDataClass(1, 2)
+    assert t.to_dict() == {"foo": 1, "bar": 2}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -246,7 +246,7 @@ def test_lazy_compilation():
     assert obj.to_dict() == {"x": 42}
 
 
-def test_sort_keys():
+def test_sort_keys_with_mixin():
     @dataclass
     class SortedDataClass(DataClassDictMixin):
         foo: int
@@ -273,3 +273,36 @@ def test_sort_keys():
 
     t = UnSortedDataClass(1, 2)
     assert t.to_dict() == {"foo": 1, "bar": 2}
+
+
+@dataclass
+class SortedDataClass:
+    foo: int
+    bar: int
+
+
+def test_sort_keys_plain_dataclass():
+    @dataclass
+    class RootSortedModel(DataClassDictMixin):
+        sub: SortedDataClass
+
+        class Config(BaseConfig):
+            sort_keys = True
+
+    @dataclass
+    class RootUnSortedModel(DataClassDictMixin):
+        sub: SortedDataClass
+
+        class Config(BaseConfig):
+            sort_keys = False
+
+    t = RootSortedModel(SortedDataClass(1, 2))
+    assert t.to_dict() == {"sub": {"bar": 2, "foo": 1}}
+    assert (
+        RootSortedModel.from_dict({"sub": {"bar": 2, "foo": 1}})
+        == RootSortedModel.from_dict({"sub": {"foo": 1, "bar": 2}})
+        == t
+    )
+
+    t = RootUnSortedModel(SortedDataClass(1, 2))
+    assert t.to_dict() == {"sub": {"foo": 1, "bar": 2}}


### PR DESCRIPTION
Hi,

Thought this is small enough to directly open a PR and see if you would support this feature.

What: add a `sort_keys` option for `BaseConfig` which would efficiently generate serialization code such that keys are sorted on creation (which in many cases will make much heavier encoder approach unnecessary).

What's missing: 
- I've only added the feature to Mixin subclasses for now, but not for arbitrary dataclasses
- I haven't added any docs, since there is no guarantee you would approve this PR
- I've only added one test, maybe you would want additional ones

Rationale:
I am using key sort (via `__post_serialize__` [hook](https://github.com/mishamsk/pyoak/blob/9c69c5dd0f4bc55be0db6d02e866d121904a333e/src/pyoak/serialize.py#L95)) a lot in order to maintain stable serialized view of my objects (those pesky trees). This would make it more efficient (depending on how classes are defined of course).
