### PR TITLE
Remove Python 3.7 support remains

### DIFF
--- a/mashumaro/config.py
+++ b/mashumaro/config.py
@@ -1,14 +1,8 @@
-from typing import Any, Callable, Dict, List, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Type, Union
 
-from mashumaro.core.const import PEP_586_COMPATIBLE, Sentinel
+from mashumaro.core.const import Sentinel
 from mashumaro.dialect import Dialect
 from mashumaro.types import Discriminator, SerializationStrategy
-
-if PEP_586_COMPATIBLE:
-    from typing import Literal  # type: ignore
-else:
-    from typing_extensions import Literal  # type: ignore
-
 
 __all__ = [
     "BaseConfig",

--- a/mashumaro/core/const.py
+++ b/mashumaro/core/const.py
@@ -10,7 +10,6 @@ __all__ = [
     "PY_310_MIN",
     "PY_311_MIN",
     "PEP_585_COMPATIBLE",
-    "PEP_586_COMPATIBLE",
     "Sentinel",
 ]
 
@@ -27,7 +26,6 @@ PY_39_MIN = PY_39 or PY_310_MIN
 PY_38_MIN = PY_38 or PY_39_MIN
 
 PEP_585_COMPATIBLE = PY_39_MIN  # Type Hinting Generics In Standard Collections
-PEP_586_COMPATIBLE = PY_38_MIN  # Literal Types
 
 
 class Sentinel(enum.Enum):

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -8,12 +8,7 @@ import pytest
 import typing_extensions
 
 from mashumaro import DataClassDictMixin
-from mashumaro.core.const import (
-    PEP_585_COMPATIBLE,
-    PY_38,
-    PY_38_MIN,
-    PY_310_MIN,
-)
+from mashumaro.core.const import PEP_585_COMPATIBLE, PY_38, PY_310_MIN
 from mashumaro.core.meta.code.builder import CodeBuilder
 
 # noinspection PyProtectedMember
@@ -542,12 +537,8 @@ def test_get_literal_values():
 
 
 def test_type_name_literal():
-    if PY_38_MIN:
-        module = typing
-    else:
-        module = typing_extensions
     assert type_name(
-        getattr(module, "Literal")[
+        getattr(typing, "Literal")[
             1,
             "a",
             b"\x00",
@@ -564,7 +555,7 @@ def test_type_name_literal():
             typing_extensions.Literal[typing_extensions.Literal["b", "c"]],
         ]
     ) == (
-        f"{module.__name__}.Literal[1, 'a', b'\\x00', True, False, None, "
+        f"typing.Literal[1, 'a', b'\\x00', True, False, None, "
         "tests.entities.MyEnum.a, tests.entities.MyStrEnum.a, "
         "tests.entities.MyNativeStrEnum.a, tests.entities.MyIntEnum.a, "
         "tests.entities.MyFlag.a, tests.entities.MyIntFlag.a, 2, 3, 'b', 'c']"


### PR DESCRIPTION
There are still unnecessary constants `PY_38_MIN` and `PEP_586_COMPATIBLE` which we can safely remove.