### PR TITLE
Fix sorted_keys tests

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -264,15 +264,10 @@ def test_sort_keys_with_mixin():
             sort_keys = False
 
     t = SortedDataClass(1, 2)
-    assert t.to_dict() == {"bar": 2, "foo": 1}
-    assert (
-        SortedDataClass.from_dict({"bar": 2, "foo": 1})
-        == SortedDataClass.from_dict({"foo": 1, "bar": 2})
-        == t
-    )
+    assert str(t.to_dict()) == "{'bar': 2, 'foo': 1}"
 
     t = UnSortedDataClass(1, 2)
-    assert t.to_dict() == {"foo": 1, "bar": 2}
+    assert str(t.to_dict()) == "{'foo': 1, 'bar': 2}"
 
 
 @dataclass
@@ -280,29 +275,50 @@ class SortedDataClass:
     foo: int
     bar: int
 
+    class Config(BaseConfig):
+        sort_keys = True
+
+
+@dataclass
+class UnSortedDataClass:
+    foo: int
+    bar: int
+
+    class Config(BaseConfig):
+        sort_keys = False
+
 
 def test_sort_keys_plain_dataclass():
     @dataclass
     class RootSortedModel(DataClassDictMixin):
-        sub: SortedDataClass
+        unsorted_sub: UnSortedDataClass
+        sorted_sub: SortedDataClass
 
         class Config(BaseConfig):
             sort_keys = True
 
     @dataclass
     class RootUnSortedModel(DataClassDictMixin):
-        sub: SortedDataClass
+        unsorted_sub: UnSortedDataClass
+        sorted_sub: SortedDataClass
 
         class Config(BaseConfig):
             sort_keys = False
 
-    t = RootSortedModel(SortedDataClass(1, 2))
-    assert t.to_dict() == {"sub": {"bar": 2, "foo": 1}}
-    assert (
-        RootSortedModel.from_dict({"sub": {"bar": 2, "foo": 1}})
-        == RootSortedModel.from_dict({"sub": {"foo": 1, "bar": 2}})
-        == t
+    t = RootSortedModel(
+        unsorted_sub=UnSortedDataClass(1, 2),
+        sorted_sub=SortedDataClass(1, 2),
+    )
+    assert str(t.to_dict()) == (
+        "{'sorted_sub': {'bar': 2, 'foo': 1}, "
+        "'unsorted_sub': {'foo': 1, 'bar': 2}}"
     )
 
-    t = RootUnSortedModel(SortedDataClass(1, 2))
-    assert t.to_dict() == {"sub": {"foo": 1, "bar": 2}}
+    t = RootUnSortedModel(
+        unsorted_sub=UnSortedDataClass(1, 2),
+        sorted_sub=SortedDataClass(1, 2),
+    )
+    assert str(t.to_dict()) == (
+        "{'unsorted_sub': {'foo': 1, 'bar': 2}, "
+        "'sorted_sub': {'bar': 2, 'foo': 1}}"
+    )


### PR DESCRIPTION
This pull request fixes the tests for `sort_keys` feature introduced in #157  by comparing string representations of two dictionaries instead of the dictionaries themselves.