### PR TITLE
Adds a configuration option to allow mixed alias/unaliased field name use when deserializing

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Table of contents
         * [`discriminator` config option](#discriminator-config-option)
         * [`lazy_compilation` config option](#lazy_compilation-config-option)
         * [`sort_keys` config option](#sort_keys-config-option)
+        * [`loose_deserialization` config option](#loose_deserialization-config-option)
     * [Passing field values as is](#passing-field-values-as-is)
     * [Extending existing types](#extending-existing-types)
     * [Dialects](#dialects)
@@ -1389,6 +1390,36 @@ class SortedDataClass(DataClassDictMixin):
 
 t = SortedDataClass(1, 2)
 assert t.to_dict() == {"bar": 2, "foo": 1}
+```
+
+#### `loose_deserialization` config option
+
+When using aliases, the deserializer defaults to requiring the keys to match
+what is defined as the alias in the metadata.
+If the flexibility to deserialize aliased and unaliased keys is required then
+the config option `loose_deserialization = True` can be set to enable the
+feature.
+
+```python
+from dataclasses import dataclass, field
+from mashumaro import DataClassDictMixin
+from mashumaro.config import BaseConfig, TO_DICT_ADD_BY_ALIAS_FLAG
+
+@dataclass
+class AliasedDataClass(DataClassDictMixin):
+    foo: int = field(metadata={"alias": "alias_foo"})
+    bar: int = field(metadata={"alias": "alias_bar"})
+
+    class Config(BaseConfig):
+        serialize_by_alias = True
+        loose_deserialization = True
+        code_generation_options = [TO_DICT_ADD_BY_ALIAS_FLAG]
+
+no_alias_dict = {"bar": 2, "foo": 1}
+# Will raise `mashumaro.exceptions.MissingField` if loose_deserialization is
+# False
+t = AliasedDataClass.from_dict(no_alias_dict)
+assert t.to_dict(by_alias=False) == {"bar": 2, "foo": 1}
 ```
 
 ### Passing field values as is

--- a/mashumaro/config.py
+++ b/mashumaro/config.py
@@ -49,3 +49,5 @@ class BaseConfig:
     discriminator: Optional[Discriminator] = None
     lazy_compilation: bool = False
     sort_keys: bool = False
+    loose_deserialization: bool = False
+

--- a/mashumaro/core/meta/code/builder.py
+++ b/mashumaro/core/meta/code/builder.py
@@ -554,16 +554,29 @@ class CodeBuilder:
                 could_be_none=False if could_be_none else True,
             )
         )
-        if unpacked_value != "value":
-            self.add_line(f"value = d.get('{alias or fname}', MISSING)")
-            packed_value = "value"
-        elif has_default:
-            self.add_line(f"value = d.get('{alias or fname}', MISSING)")
-            packed_value = "value"
+        if self.get_config().loose_deserialization:
+            if unpacked_value != "value":
+                self.add_line(f"value = d.get('{alias}', d.get('{fname}', MISSING))")
+                packed_value = "value"
+            elif has_default:
+                self.add_line(f"value = d.get('{alias}', d.get('{fname}', MISSING))")
+                packed_value = "value"
+            else:
+                self.add_line(f"__{fname} = d.get('{alias}', d.get('{fname}', MISSING))")
+                packed_value = f"__{fname}"
+                unpacked_value = packed_value
         else:
-            self.add_line(f"__{fname} = d.get('{alias or fname}', MISSING)")
-            packed_value = f"__{fname}"
-            unpacked_value = packed_value
+            if unpacked_value != "value":
+                self.add_line(f"value = d.get('{alias or fname}', MISSING)")
+                packed_value = "value"
+            elif has_default:
+                self.add_line(f"value = d.get('{alias or fname}', MISSING)")
+                packed_value = "value"
+            else:
+                self.add_line(
+                    f"__{fname} = d.get('{alias or fname}', MISSING)")
+                packed_value = f"__{fname}"
+                unpacked_value = packed_value
         if not has_default:
             with self.indent(f"if {packed_value} is MISSING:"):
                 self.add_line(

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -176,3 +176,21 @@ def test_no_serialize_by_alias_with_serialize_by_alias_and_optional():
 
     assert DataClass(x=123).to_dict() == {"alias": 123}
     assert DataClass(x=None).to_dict() == {"alias": None}
+
+
+def test_by_field_with_loose_deserialize():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        a: int = field(metadata={"alias": "alias_a"})
+        b: Optional[int] = field(metadata={"alias": "alias_b"})
+
+        class Config(BaseConfig):
+            serialize_by_alias = True
+            code_generation_options = [TO_DICT_ADD_BY_ALIAS_FLAG]
+            loose_deserialization = True
+
+    instance = DataClass(a=123, b=456)
+    assert DataClass.from_dict({"a": 123, "alias_b": 456}) == instance
+    assert instance.to_dict() == {"alias_a": 123, "alias_b": 456}
+    assert instance.to_dict(by_alias=False) == {"a": 123, "b": 456}
+


### PR DESCRIPTION

Problem statement:

Our company uses mashumaro extensively and have several interconnected services that use the same shared data structures; however, in some places it is useful for the serialized payloads to be human readable and in other places having the keys be "minified" using aliases is more important. To prevent needing to duplicate the dataclasses around the codebase, we use dialects to control how the data is serialized, but when the data is deserialized in the current mashumaro build the fieldnames must match the alias. 

Changes: 

Adds an option called `loose_deserialization` to the BaseConfig to allow for mixed aliased/unaliased usage during deserialization.
