### PR TITLE
Adds support for fields with local dataclass types

### DIFF
--- a/mashumaro/core/meta/code/builder.py
+++ b/mashumaro/core/meta/code/builder.py
@@ -45,6 +45,7 @@ from mashumaro.core.meta.helpers import (
     is_hashable,
     is_init_var,
     is_literal,
+    is_local_type,
     is_named_tuple,
     is_optional,
     is_type_var_any,
@@ -52,7 +53,12 @@ from mashumaro.core.meta.helpers import (
     substitute_type_params,
     type_name,
 )
-from mashumaro.core.meta.types.common import FieldContext, NoneType, ValueSpec
+from mashumaro.core.meta.types.common import (
+    FieldContext,
+    NoneType,
+    ValueSpec,
+    clean_id,
+)
 from mashumaro.core.meta.types.pack import PackerRegistry
 from mashumaro.core.meta.types.unpack import (
     SubtypeUnpackerBuilder,
@@ -306,6 +312,7 @@ class CodeBuilder:
             else:
                 print(f"{type_name(self.cls)}:")
             print(code)
+
         exec(code, self.globals, self.__dict__)
 
     def evaluate_forward_ref(
@@ -1256,6 +1263,11 @@ class FieldUnpackerCodeBlockBuilder:
                 fname
             ),
         )
+
+        if is_local_type(ftype):
+            field_type = clean_id(field_type)
+            self.ensure_object_imported(ftype, field_type)
+
         could_be_none = (
             ftype in (typing.Any, type(None), None)
             or is_type_var_any(self.parent.get_real_type(fname, ftype))

--- a/mashumaro/core/meta/code/builder.py
+++ b/mashumaro/core/meta/code/builder.py
@@ -45,7 +45,7 @@ from mashumaro.core.meta.helpers import (
     is_hashable,
     is_init_var,
     is_literal,
-    is_local_type,
+    is_local_type_name,
     is_named_tuple,
     is_optional,
     is_type_var_any,
@@ -1264,9 +1264,9 @@ class FieldUnpackerCodeBlockBuilder:
             ),
         )
 
-        if is_local_type(ftype):
+        if is_local_type_name(field_type):
             field_type = clean_id(field_type)
-            self.ensure_object_imported(ftype, field_type)
+            self.parent.ensure_object_imported(ftype, field_type)
 
         could_be_none = (
             ftype in (typing.Any, type(None), None)

--- a/mashumaro/core/meta/helpers.py
+++ b/mashumaro/core/meta/helpers.py
@@ -389,8 +389,8 @@ def is_literal(typ: Type) -> bool:
     return False
 
 
-def is_local_type(typ: Type) -> bool:
-    return "<locals>" in getattr(typ, "__qualname__", "")
+def is_local_type_name(type_name: str) -> bool:
+    return "<locals>" in type_name
 
 
 def not_none_type_arg(

--- a/mashumaro/core/meta/helpers.py
+++ b/mashumaro/core/meta/helpers.py
@@ -389,6 +389,10 @@ def is_literal(typ: Type) -> bool:
     return False
 
 
+def is_local_type(typ: Type) -> bool:
+    return "<locals>" in getattr(typ, "__qualname__", "")
+
+
 def not_none_type_arg(
     type_args: Tuple[Type, ...],
     resolved_type_params: Optional[Dict[Type, Type]] = None,

--- a/mashumaro/core/meta/types/common.py
+++ b/mashumaro/core/meta/types/common.py
@@ -1,4 +1,5 @@
 import collections.abc
+import re
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, replace
@@ -300,7 +301,11 @@ def random_hex() -> str:
     return str(uuid.uuid4().hex)
 
 
+_PY_VALID_ID_RE = re.compile(r"\W|^(?=\d)")
+
+
 def clean_id(value: str) -> str:
-    for c in ".<>":
-        value = value.replace(c, "_")
-    return value
+    if not value:
+        return "_"
+
+    return _PY_VALID_ID_RE.sub("_", value)

--- a/mashumaro/core/meta/types/pack.py
+++ b/mashumaro/core/meta/types/pack.py
@@ -32,6 +32,7 @@ from mashumaro.core.meta.helpers import (
     is_final,
     is_generic,
     is_literal,
+    is_local_type_name,
     is_named_tuple,
     is_new_type,
     is_not_required,
@@ -306,6 +307,11 @@ def pack_union(
                 spec.field_ctx.name
             ),
         )
+
+        if is_local_type_name(field_type):
+            field_type = clean_id(field_type)
+            spec.builder.ensure_object_imported(spec.type, field_type)
+
         if spec.builder.is_nailed:
             lines.append(
                 "raise InvalidFieldValue("
@@ -359,6 +365,13 @@ def pack_literal(spec: ValueSpec) -> Expression:
                     typ=value_type,
                     resolved_type_params=resolved_type_params,
                 )
+
+                if is_local_type_name(enum_type_name):
+                    enum_type_name = clean_id(enum_type_name)
+                    spec.builder.ensure_object_imported(
+                        value_type, enum_type_name
+                    )
+
                 with lines.indent(
                     f"if value == {enum_type_name}.{literal_value.name}:"
                 ):
@@ -373,6 +386,11 @@ def pack_literal(spec: ValueSpec) -> Expression:
             typ=spec.type,
             resolved_type_params=resolved_type_params,
         )
+
+        if is_local_type_name(field_type):
+            field_type = clean_id(field_type)
+            spec.builder.ensure_object_imported(spec.type, field_type)
+
         if spec.builder.is_nailed:
             lines.append(
                 f"raise InvalidFieldValue('{spec.field_ctx.name}',"

--- a/mashumaro/core/meta/types/unpack.py
+++ b/mashumaro/core/meta/types/unpack.py
@@ -39,6 +39,7 @@ from mashumaro.core.meta.helpers import (
     is_final,
     is_generic,
     is_literal,
+    is_local_type_name,
     is_named_tuple,
     is_new_type,
     is_not_required,
@@ -180,6 +181,10 @@ class UnionUnpackerBuilder(AbstractUnpackerBuilder):
             ),
         )
         if spec.builder.is_nailed:
+            if is_local_type_name(field_type):
+                field_type = clean_id(field_type)
+                spec.builder.ensure_object_imported(spec.type, field_type)
+
             lines.append(
                 "raise InvalidFieldValue("
                 f"'{spec.field_ctx.name}',{field_type},value,cls)"
@@ -203,7 +208,15 @@ class LiteralUnpackerBuilder(AbstractUnpackerBuilder):
     def _add_body(self, spec: ValueSpec, lines: CodeLines) -> None:
         for literal_value in get_literal_values(spec.type):
             if isinstance(literal_value, enum.Enum):
-                enum_type_name = type_name(type(literal_value))
+                lit_type = type(literal_value)
+                enum_type_name = type_name(lit_type)
+
+                if is_local_type_name(enum_type_name):
+                    enum_type_name = clean_id(enum_type_name)
+                    spec.builder.ensure_object_imported(
+                        lit_type, enum_type_name
+                    )
+
                 with lines.indent(
                     f"if value == {enum_type_name}.{literal_value.name}.value:"
                 ):
@@ -299,6 +312,10 @@ class DiscriminatedUnionUnpackerBuilder(AbstractUnpackerBuilder):
         variants_attr_holder = self._get_variants_attr_holder(spec)
         variants = self._get_variant_names_iterable(spec)
         variants_type_expr = type_name(spec.type)
+
+        if is_local_type_name(variants_type_expr):
+            variants_type_expr = clean_id(variants_type_expr)
+            spec.builder.ensure_object_imported(spec.type, variants_type_expr)
 
         if variants_attr not in variants_attr_holder.__dict__:
             setattr(variants_attr_holder, variants_attr, {})
@@ -565,7 +582,14 @@ def _unpack_annotated_serializable_type(
         ],
     )
     unpacker = UnpackerRegistry.get(spec.copy(type=value_type))
-    return f"{type_name(spec.type)}._deserialize({unpacker})"
+
+    field_type = type_name(spec.type)
+
+    if is_local_type_name(field_type):
+        field_type = clean_id(field_type)
+        spec.builder.ensure_object_imported(spec.type, field_type)
+
+    return f"{field_type}._deserialize({unpacker})"
 
 
 @register
@@ -578,7 +602,12 @@ def unpack_serializable_type(spec: ValueSpec) -> Optional[Expression]:
     if spec.origin_type.__use_annotations__:
         return _unpack_annotated_serializable_type(spec)
     else:
-        return f"{type_name(spec.type)}._deserialize({spec.expression})"
+        field_type = type_name(spec.type)
+        if is_local_type_name(field_type):
+            field_type = clean_id(field_type)
+            spec.builder.ensure_object_imported(spec.type, field_type)
+
+        return f"{field_type}._deserialize({spec.expression})"
 
 
 @register
@@ -588,8 +617,14 @@ def unpack_generic_serializable_type(spec: ValueSpec) -> Optional[Expression]:
             type_arg_names = ", ".join(
                 list(map(type_name, get_args(spec.type)))
             )
+            field_type = type_name(spec.origin_type)
+
+            if is_local_type_name(field_type):
+                field_type = clean_id(field_type)
+                spec.builder.ensure_object_imported(spec.type, field_type)
+
             return (
-                f"{type_name(spec.type)}._deserialize({spec.expression}, "
+                f"{field_type}._deserialize({spec.expression}, "
                 f"[{type_arg_names}])"
             )
 
@@ -990,7 +1025,12 @@ def unpack_named_tuple(spec: ValueSpec) -> Expression:
         unpackers.append(unpacker)
 
     if not defaults:
-        return f"{type_name(spec.type)}({', '.join(unpackers)})"
+        field_type = type_name(spec.type)
+        if is_local_type_name(field_type):
+            field_type = clean_id(field_type)
+            spec.builder.ensure_object_imported(spec.type, field_type)
+
+        return f"{field_type}({', '.join(unpackers)})"
 
     lines = CodeLines()
     method_name = (
@@ -1015,7 +1055,13 @@ def unpack_named_tuple(spec: ValueSpec) -> Expression:
                 lines.append(f"fields.append({unpacker})")
         with lines.indent("except IndexError:"):
             lines.append("pass")
-        lines.append(f"return {type_name(spec.type)}(*fields)")
+
+        field_type = type_name(spec.type)
+        if is_local_type_name(field_type):
+            field_type = clean_id(field_type)
+            spec.builder.ensure_object_imported(spec.type, field_type)
+
+        lines.append(f"return {field_type}(*fields)")
     lines.append(
         f"setattr({spec.cls_attrs_name}, '{method_name}', {method_name})"
     )
@@ -1194,10 +1240,22 @@ def unpack_pathlike(spec: ValueSpec) -> Optional[Expression]:
         spec.builder.ensure_module_imported(pathlib)
         return f"{type_name(pathlib.PurePath)}({spec.expression})"
     elif issubclass(spec.origin_type, os.PathLike):
-        return f"{type_name(spec.origin_type)}({spec.expression})"
+        field_type = type_name(spec.origin_type)
+
+        if is_local_type_name(field_type):
+            field_type = clean_id(field_type)
+            spec.builder.ensure_object_imported(spec.type, field_type)
+
+        return f"{field_type}({spec.expression})"
 
 
 @register
 def unpack_enum(spec: ValueSpec) -> Optional[Expression]:
     if issubclass(spec.origin_type, enum.Enum):
-        return f"{type_name(spec.origin_type)}({spec.expression})"
+        field_type = type_name(spec.origin_type)
+
+        if is_local_type_name(field_type):
+            field_type = clean_id(field_type)
+            spec.builder.ensure_object_imported(spec.type, field_type)
+
+        return f"{field_type}({spec.expression})"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -262,3 +262,17 @@ def test_kw_args_when_pos_arg_is_overridden_with_field():
     assert loaded.pos2 == 2
     assert loaded.pos3 == 3
     assert loaded.kw1 == 4
+
+
+def test_local_type():
+    @dataclass
+    class LocalType:
+        pass
+
+    @dataclass
+    class DataClassWithLocalType(DataClassDictMixin):
+        x: LocalType
+
+    obj = DataClassWithLocalType(LocalType())
+    assert obj.to_dict() == {"x": {}}
+    assert DataClassWithLocalType.from_dict({"x": {}}) == obj


### PR DESCRIPTION
Hey,

This PR makes the following work:
```py
def test_local_type():
    @dataclass
    class LocalType:
        pass

    @dataclass
    class DataClassWithLocalType(DataClassDictMixin):
        x: LocalType

    obj = DataClassWithLocalType(LocalType())
    assert obj.to_dict() == {"x": {}}
    assert DataClassWithLocalType.from_dict({"x": {}}) == obj
```

First why: as you know, I use a custom deserialization base class that maintains a global registry of DataClassDictMixin subclasses allowing discrimination by subclass. I haven't migrated to 3.10, so it is still there. 

This in turn means that at any given moment all subclass names must be unique. This is inconvenient for tests, but since so far mashumaro enforces classes in global scope, there is no easy way to create isolated tests, that define classes and then remove them.

Not sure if there are a lot of real life use cases outside of tests, but there may be...

The way I've implemented it is minimally disruptive. It should change nothing unless the type annotation is a locally defined class. Generally speaking, the current code generation can stop relying on fully qualified names of types entirely and use my change that just adds them to locals before executing. But that may have bigger consequences, so I opted no to do that.

Fixes #182