### PR TITLE
Fix bug with default value of field with discriminator on JSON Schema generation

### DIFF
--- a/mashumaro/jsonschema/schema.py
+++ b/mashumaro/jsonschema/schema.py
@@ -290,7 +290,7 @@ def _create_unique_class_name(base_name: str, *args: Any) -> str:
 
 
 def _create_and_assign_global_class(
-    f_type: type, f_value: Any, config_cls: type[BaseConfig]
+    f_type: Type, f_value: Any, config_cls: Type[BaseConfig]
 ) -> Any:
     class_name = _create_unique_class_name('CC', f_type, f_value, config_cls)
     config_type = type('Config', (config_cls,), {})

--- a/mashumaro/jsonschema/schema.py
+++ b/mashumaro/jsonschema/schema.py
@@ -285,7 +285,7 @@ def _get_schema_or_none(
     return schema
 
 
-def _create_unique_class_name(base_name: str, *args) -> str:
+def _create_unique_class_name(base_name: str, *args: Any) -> str:
     return f"{base_name}_{hashlib.blake2b(str(args).encode()).hexdigest()}"
 
 

--- a/tests/test_jsonschema/test_jsonschema_generation.py
+++ b/tests/test_jsonschema/test_jsonschema_generation.py
@@ -1249,6 +1249,7 @@ def test_jsonschema_with_additional_properties_schema():
 class A:
     value = 'a'
 
+
 @dataclass
 class B:
     value = 'b'

--- a/tests/test_jsonschema/test_jsonschema_generation.py
+++ b/tests/test_jsonschema/test_jsonschema_generation.py
@@ -73,7 +73,7 @@ from mashumaro.jsonschema.models import (
     JSONSchemaStringFormat,
 )
 from mashumaro.jsonschema.schema import UTC_OFFSET_PATTERN, EmptyJSONSchema
-from mashumaro.types import SerializationStrategy
+from mashumaro.types import Discriminator, SerializationStrategy
 from tests.entities import (
     CustomPath,
     GenericNamedTuple,
@@ -1243,3 +1243,118 @@ def test_jsonschema_with_additional_properties_schema():
         required=["x"],
     )
     assert build_json_schema(DataClass) == schema
+
+
+@dataclass
+class A:
+    value = 'a'
+
+@dataclass
+class B:
+    value = 'b'
+
+
+def test_jsonschema_with_discriminator():
+    @dataclass
+    class Main:
+        value: Annotated[
+            A | B,
+            Discriminator(field='value', include_supertypes=True)
+        ]
+
+    schema = JSONObjectSchema(
+        title="Main",
+        properties={
+            "value": JSONSchema(
+                anyOf=[
+                    JSONObjectSchema(
+                        type=JSONSchemaInstanceType.OBJECT,
+                        title="A",
+                        additionalProperties=False,
+                    ),
+                    JSONObjectSchema(
+                        type=JSONSchemaInstanceType.OBJECT,
+                        title="B",
+                        additionalProperties=False,
+                    ),
+                ],
+            ),
+        },
+        additionalProperties=False,
+        required=["value"],
+    )
+    assert build_json_schema(Main) == schema
+
+
+def test_jsonschema_with_discriminator_with_default():
+    @dataclass
+    class Main:
+        value: Annotated[
+            A | B | None,
+            Discriminator(field='value', include_supertypes=True)
+        ] = None
+
+    schema = JSONObjectSchema(
+        title="Main",
+        properties={
+            "value": JSONSchema(
+                anyOf=[
+                    JSONObjectSchema(
+                        type=JSONSchemaInstanceType.OBJECT,
+                        title="A",
+                        additionalProperties=False,
+                    ),
+                    JSONObjectSchema(
+                        type=JSONSchemaInstanceType.OBJECT,
+                        title="B",
+                        additionalProperties=False,
+                    ),
+                    JSONSchema(
+                        type=JSONSchemaInstanceType.NULL,
+                    ),
+                ],
+                default=None,
+            ),
+        },
+        additionalProperties=False,
+    )
+    assert build_json_schema(Main) == schema
+
+
+def test_jsonschema_with_optional_discriminator_and_default():
+    @dataclass
+    class Main:
+        value: Annotated[
+            A | B,
+            Discriminator(field='value', include_supertypes=True)
+        ] | None = None
+
+    schema = JSONObjectSchema(
+        title="Main",
+        properties={
+            "value": JSONSchema(
+                anyOf=[
+                    JSONSchema(
+                        anyOf=[
+                            JSONObjectSchema(
+                                type=JSONSchemaInstanceType.OBJECT,
+                                title="A",
+                                additionalProperties=False,
+                            ),
+                            JSONObjectSchema(
+                                type=JSONSchemaInstanceType.OBJECT,
+                                title="B",
+                                additionalProperties=False,
+                            ),
+                        ]
+                    ),
+                    JSONSchema(
+                        type=JSONSchemaInstanceType.NULL,
+                    ),
+                ],
+                default=None,
+            ),
+        },
+        additionalProperties=False,
+    )
+    assert build_json_schema(Main) == schema


### PR DESCRIPTION
Use case:
```python
@dataclass
class A:
    value = 'a'

@dataclass
class B:
    value = 'b'

@dataclass
class Main:
    value: Annotated[
        A | B,
        Discriminator(field='value', include_supertypes=True)
    ] | None = None
```

On JSON Schema generation of dataclass with discriminator field and default value an error caused:
```
    def _compile(self, spec: ValueSpec, lines: CodeLines) -> None:
        if spec.builder.get_config().debug:
            print(f"{type_name(spec.builder.cls)}:")
            print(lines.as_text())
>       exec(lines.as_text(), spec.builder.globals, spec.builder.__dict__)
E         File "<string>", line 8
E           return mashumaro.jsonschema.schema._default.<locals>.CC.__mashumaro_x_variants_72cfc86c11f1448d83799e7e1b77f74c__[discriminator].__mashumaro_from_dict__(value)
E                                                       ^
E       SyntaxError: invalid syntax
```

The reason is dynamic dataclass generated in `_default` method in schema.py.

This fix is about avoid usage of "in method" class generation. Instead use globals with unique class name for each unique arguments.