### PR TITLE
Forbid extra option and bubbling up the inner-most exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,82 +27,86 @@ but it also does it _super quick_.
 
 Table of contents
 -------------------------------------------------------------------------------
-* [Introduction](#introduction)
-* [Installation](#installation)
-* [Changelog](#changelog)
-* [Supported data types](#supported-data-types)
-* [Usage example](#usage-example)
-* [How does it work?](#how-does-it-work)
-* [Benchmark](#benchmark)
-* [Supported serialization formats](#supported-serialization-formats)
-  * [Basic form](#basic-form)
-  * [JSON](#json)
-  * [YAML](#yaml)
-  * [TOML](#toml)
-  * [MessagePack](#messagepack)
-* [Customization](#customization)
-    * [`SerializableType` interface](#serializabletype-interface)
-      * [User-defined types](#user-defined-types)
-      * [User-defined generic types](#user-defined-generic-types)
-    * [`SerializationStrategy`](#serializationstrategy)
-      * [Third-party types](#third-party-types)
-      * [Third-party generic types](#third-party-generic-types)
-    * [Field options](#field-options)
-        * [`serialize` option](#serialize-option)
-        * [`deserialize` option](#deserialize-option)
-        * [`serialization_strategy` option](#serialization_strategy-option)
-        * [`alias` option](#alias-option)
-    * [Config options](#config-options)
-        * [`debug` config option](#debug-config-option)
-        * [`code_generation_options` config option](#code_generation_options-config-option)
-        * [`serialization_strategy` config option](#serialization_strategy-config-option)
-        * [`aliases` config option](#aliases-config-option)
-        * [`serialize_by_alias` config option](#serialize_by_alias-config-option)
-        * [`allow_deserialization_not_by_alias` config option](#allow_deserialization_not_by_alias-config-option)
-        * [`omit_none` config option](#omit_none-config-option)
-        * [`omit_default` config option](#omit_default-config-option)
-        * [`namedtuple_as_dict` config option](#namedtuple_as_dict-config-option)
-        * [`allow_postponed_evaluation` config option](#allow_postponed_evaluation-config-option)
-        * [`dialect` config option](#dialect-config-option)
-        * [`orjson_options` config option](#orjson_options-config-option)
-        * [`discriminator` config option](#discriminator-config-option)
-        * [`lazy_compilation` config option](#lazy_compilation-config-option)
-        * [`sort_keys` config option](#sort_keys-config-option)
-    * [Passing field values as is](#passing-field-values-as-is)
-    * [Extending existing types](#extending-existing-types)
-    * [Dialects](#dialects)
-      * [`serialization_strategy` dialect option](#serialization_strategy-dialect-option)
-      * [`serialize_by_alias` dialect option](#serialize_by_alias-dialect-option)
-      * [`omit_none` dialect option](#omit_none-dialect-option)
-      * [`omit_default` dialect option](#omit_default-dialect-option)
-      * [`named_tuple_as_dict` dialect option](#namedtuple_as_dict-dialect-option)
-      * [`no_copy_collections` dialect option](#no_copy_collections-dialect-option)
-      * [Changing the default dialect](#changing-the-default-dialect)
-    * [Discriminator](#discriminator)
-      * [Subclasses distinguishable by a field](#subclasses-distinguishable-by-a-field)
-      * [Subclasses without a common field](#subclasses-without-a-common-field)
-      * [Class level discriminator](#class-level-discriminator)
-      * [Working with union of classes](#working-with-union-of-classes)
-      * [Using a custom variant tagger function](#using-a-custom-variant-tagger-function)
-    * [Code generation options](#code-generation-options)
-        * [Add `omit_none` keyword argument](#add-omit_none-keyword-argument)
-        * [Add `by_alias` keyword argument](#add-by_alias-keyword-argument)
-        * [Add `dialect` keyword argument](#add-dialect-keyword-argument)
-        * [Add `context` keyword argument](#add-context-keyword-argument)
-    * [Generic dataclasses](#generic-dataclasses)
-      * [Generic dataclass inheritance](#generic-dataclass-inheritance)
-      * [Generic dataclass in a field type](#generic-dataclass-in-a-field-type)
-    * [`GenericSerializableType` interface](#genericserializabletype-interface)
-    * [Serialization hooks](#serialization-hooks)
-        * [Before deserialization](#before-deserialization)
-        * [After deserialization](#after-deserialization)
-        * [Before serialization](#before-serialization)
-        * [After serialization](#after-serialization)
-* [JSON Schema](#json-schema)
-    * [Building JSON Schema](#building-json-schema)
-    * [JSON Schema constraints](#json-schema-constraints)
-    * [Extending JSON Schema](#extending-json-schema)
-    * [JSON Schema and custom serialization methods](#json-schema-and-custom-serialization-methods)
+- [Table of contents](#table-of-contents)
+- [Introduction](#introduction)
+- [Installation](#installation)
+- [Changelog](#changelog)
+- [Supported data types](#supported-data-types)
+- [Usage example](#usage-example)
+- [How does it work?](#how-does-it-work)
+- [Benchmark](#benchmark)
+- [Supported serialization formats](#supported-serialization-formats)
+    - [Basic form](#basic-form)
+    - [JSON](#json)
+        - [json library](#json-library)
+        - [orjson library](#orjson-library)
+    - [YAML](#yaml)
+    - [TOML](#toml)
+    - [MessagePack](#messagepack)
+- [Customization](#customization)
+    - [SerializableType interface](#serializabletype-interface)
+        - [User-defined types](#user-defined-types)
+        - [User-defined generic types](#user-defined-generic-types)
+    - [SerializationStrategy](#serializationstrategy)
+        - [Third-party types](#third-party-types)
+        - [Third-party generic types](#third-party-generic-types)
+    - [Field options](#field-options)
+        - [`serialize` option](#serialize-option)
+        - [`deserialize` option](#deserialize-option)
+        - [`serialization_strategy` option](#serialization_strategy-option)
+        - [`alias` option](#alias-option)
+    - [Config options](#config-options)
+        - [`debug` config option](#debug-config-option)
+        - [`code_generation_options` config option](#code_generation_options-config-option)
+        - [`serialization_strategy` config option](#serialization_strategy-config-option)
+        - [`aliases` config option](#aliases-config-option)
+        - [`serialize_by_alias` config option](#serialize_by_alias-config-option)
+        - [`allow_deserialization_not_by_alias` config option](#allow_deserialization_not_by_alias-config-option)
+        - [`omit_none` config option](#omit_none-config-option)
+        - [`omit_default` config option](#omit_default-config-option)
+        - [`namedtuple_as_dict` config option](#namedtuple_as_dict-config-option)
+        - [`allow_postponed_evaluation` config option](#allow_postponed_evaluation-config-option)
+        - [`dialect` config option](#dialect-config-option)
+        - [`orjson_options` config option](#orjson_options-config-option)
+        - [`discriminator` config option](#discriminator-config-option)
+        - [`lazy_compilation` config option](#lazy_compilation-config-option)
+        - [`sort_keys` config option](#sort_keys-config-option)
+        - [`forbid_extra_keys` config option](#forbid_extra_keys-config-option)
+    - [Passing field values as is](#passing-field-values-as-is)
+    - [Extending existing types](#extending-existing-types)
+    - [Dialects](#dialects)
+        - [`serialization_strategy` dialect option](#serialization_strategy-dialect-option)
+        - [`serialize_by_alias` dialect option](#serialize_by_alias-dialect-option)
+        - [`omit_none` dialect option](#omit_none-dialect-option)
+        - [`omit_default` dialect option](#omit_default-dialect-option)
+        - [`namedtuple_as_dict` dialect option](#namedtuple_as_dict-dialect-option)
+        - [`no_copy_collections` dialect option](#no_copy_collections-dialect-option)
+        - [Changing the default dialect](#changing-the-default-dialect)
+    - [Discriminator](#discriminator)
+        - [Subclasses distinguishable by a field](#subclasses-distinguishable-by-a-field)
+        - [Subclasses without a common field](#subclasses-without-a-common-field)
+        - [Class level discriminator](#class-level-discriminator)
+        - [Working with union of classes](#working-with-union-of-classes)
+        - [Using a custom variant tagger function](#using-a-custom-variant-tagger-function)
+    - [Code generation options](#code-generation-options)
+        - [Add `omit_none` keyword argument](#add-omit_none-keyword-argument)
+        - [Add `by_alias` keyword argument](#add-by_alias-keyword-argument)
+        - [Add `dialect` keyword argument](#add-dialect-keyword-argument)
+        - [Add `context` keyword argument](#add-context-keyword-argument)
+    - [Generic dataclasses](#generic-dataclasses)
+        - [Generic dataclass inheritance](#generic-dataclass-inheritance)
+        - [Generic dataclass in a field type](#generic-dataclass-in-a-field-type)
+    - [GenericSerializableType interface](#genericserializabletype-interface)
+    - [Serialization hooks](#serialization-hooks)
+        - [Before deserialization](#before-deserialization)
+        - [After deserialization](#after-deserialization)
+        - [Before serialization](#before-serialization)
+        - [After serialization](#after-serialization)
+- [JSON Schema](#json-schema)
+    - [Building JSON Schema](#building-json-schema)
+    - [JSON Schema constraints](#json-schema-constraints)
+    - [Extending JSON Schema](#extending-json-schema)
+    - [JSON Schema and custom serialization methods](#json-schema-and-custom-serialization-methods)
 
 Introduction
 -------------------------------------------------------------------------------
@@ -148,8 +152,8 @@ For convenience, there is a table below that outlines the
 last version of `mashumaro` that can be installed on unmaintained versions
 of Python.
 
-| Python Version | Last Version of mashumaro                                        | Python EOL |
-|----------------|--------------------------------------------------------------------|------------|
+| Python Version | Last Version of mashumaro                                          | Python EOL |
+| -------------- | ------------------------------------------------------------------ | ---------- |
 | 3.7            | [3.9.1](https://github.com/Fatal1ty/mashumaro/releases/tag/v3.9.1) | 2023-06-27 |
 | 3.6            | [3.1.1](https://github.com/Fatal1ty/mashumaro/releases/tag/v3.1.1) | 2021-12-23 |
 
@@ -1127,7 +1131,7 @@ that all possible engines depend on the data type that this option is used
 with. At this moment there are next serialization engines to choose from:
 
 | Applicable data types      | Supported engines    | Description                                                                                                                                                                                                  |
-|:---------------------------|:---------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| :------------------------- | :------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `NamedTuple`, `namedtuple` | `as_list`, `as_dict` | How to pack named tuples. By default `as_list` engine is used that means your named tuple class instance will be packed into a list of its values. You can pack it into a dictionary using `as_dict` engine. |
 | `Any`                      | `omit`               | Skip the field during serialization                                                                                                                                                                          |
 
@@ -1172,7 +1176,7 @@ that all possible engines depend on the data type that this option is used
 with. At this moment there are next deserialization engines to choose from:
 
 | Applicable data types      | Supported engines                                                                                                                   | Description                                                                                                                                                                                                                                                                                             |
-|:---------------------------|:------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| :------------------------- | :---------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `datetime`, `date`, `time` | [`ciso8601`](https://github.com/closeio/ciso8601#supported-subset-of-iso-8601), [`pendulum`](https://github.com/sdispater/pendulum) | How to parse datetime string. By default native [`fromisoformat`](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat) of corresponding class will be used for `datetime`, `date` and `time` fields. It's the fastest way in most cases, but you can choose an alternative. |
 | `NamedTuple`, `namedtuple` | `as_list`, `as_dict`                                                                                                                | How to unpack named tuples. By default `as_list` engine is used that means your named tuple class instance will be created from a list of its values. You can unpack it from a dictionary using `as_dict` engine.                                                                                       |
 
@@ -1317,7 +1321,7 @@ The following table provides a brief overview of all the available constants
 described below.
 
 | Constant                                                        | Description                                                          |
-|:----------------------------------------------------------------|:---------------------------------------------------------------------|
+| :-------------------------------------------------------------- | :------------------------------------------------------------------- |
 | [`TO_DICT_ADD_OMIT_NONE_FLAG`](#add-omit_none-keyword-argument) | Adds `omit_none` keyword-only argument to `to_*` methods.            |
 | [`TO_DICT_ADD_BY_ALIAS_FLAG`](#add-by_alias-keyword-argument)   | Adds `by_alias` keyword-only argument to `to_*` methods.             |
 | [`ADD_DIALECT_SUPPORT`](#add-dialect-keyword-argument)          | Adds `dialect` keyword-only argument to `from_*` and `to_*` methods. |
@@ -1712,6 +1716,24 @@ class SortedDataClass(DataClassDictMixin):
 t = SortedDataClass(1, 2)
 assert t.to_dict() == {"bar": 2, "foo": 1}
 ```
+
+#### `forbid_extra_keys` config option
+
+When set, the deserialization of dataclasses will fail if the input dictionary contains keys that are not present in the dataclass.
+
+```python
+from dataclasses import dataclass
+
+from mashumaro import DataClassDictMixin
+
+@dataclass
+class DataClass(DataClassDictMixin):
+    a: int
+
+DataClass.from_dict({"a": 1, "b": 2})  # ExtraKeysError: Extra keys: {'b'}
+```
+
+It plays well with `aliases` and `allow_deserialization_not_by_alias` options.
 
 ### Passing field values as is
 

--- a/mashumaro/config.py
+++ b/mashumaro/config.py
@@ -69,3 +69,4 @@ class BaseConfig:
     lazy_compilation: bool = False
     sort_keys: bool = False
     allow_deserialization_not_by_alias: bool = False
+    forbid_extra_keys: bool = False

--- a/mashumaro/core/meta/code/builder.py
+++ b/mashumaro/core/meta/code/builder.py
@@ -65,6 +65,7 @@ from mashumaro.exceptions import (  # noqa
     InvalidFieldValue,
     MissingDiscriminatorError,
     MissingField,
+    ExtraKeysError,
     SuitableVariantNotFoundError,
     ThirdPartyModuleNotFoundError,
     UnresolvedTypeReferenceError,
@@ -439,15 +440,35 @@ class CodeBuilder:
                 else:
                     missing_kw_only = True
                     kw_only_fields.add(fname)
-                filtered_fields.append((fname, ftype))
+
+                metadata = self.metadatas.get(fname, {})
+                alias = metadata.get("alias")
+                if alias is None:
+                    alias = config.aliases.get(fname)
+
+                filtered_fields.append((fname, alias, ftype))
             if filtered_fields:
+                if config.forbid_extra_keys:
+                    allowed_keys = {f[1] or f[0] for f in filtered_fields}
+
+                    if config.allow_deserialization_not_by_alias:
+                        allowed_keys |= {f[0] for f in filtered_fields}
+
+                    allowed_keys_str = "'" + "', '".join(allowed_keys) + "'"
+
+                    self.add_line("d_keys = set(d.keys())")
+                    self.add_line(
+                        f"forbidden_keys = d_keys - {{{allowed_keys_str}}}"
+                    )
+                    with self.indent("if forbidden_keys:"):
+                        self.add_line(
+                            f"raise ExtraKeysError(forbidden_keys,cls) from None"
+                        )
+
                 with self.indent("try:"):
-                    for fname, ftype in filtered_fields:
+                    for fname, alias, ftype in filtered_fields:
                         self.add_type_modules(ftype)
                         metadata = self.metadatas.get(fname, {})
-                        alias = metadata.get("alias")
-                        if alias is None:
-                            alias = config.aliases.get(fname)
                         field_block = FieldUnpackerCodeBlockBuilder(
                             self, self.lines.branch_off()
                         ).build(

--- a/mashumaro/core/meta/code/builder.py
+++ b/mashumaro/core/meta/code/builder.py
@@ -462,7 +462,8 @@ class CodeBuilder:
                     )
                     with self.indent("if forbidden_keys:"):
                         self.add_line(
-                            f"raise ExtraKeysError(forbidden_keys,cls) from None"
+                            "raise ExtraKeysError(forbidden_keys,cls) "
+                            "from None"
                         )
 
                 with self.indent("try:"):
@@ -1248,7 +1249,8 @@ class FieldUnpackerCodeBlockBuilder:
             self._set_value(field_name, unpacked_value, in_kwargs)
         with self.lines.indent("except MissingField as inner:"):
             self.lines.append(
-                f"path = '{field_name}' + '.' + inner.path if inner.path else '{field_name}'"
+                f"path = '{field_name}' + '.' + inner.path "
+                f"if inner.path else '{field_name}'"
             )
             self.lines.append(
                 "raise MissingField("
@@ -1257,7 +1259,8 @@ class FieldUnpackerCodeBlockBuilder:
             )
         with self.lines.indent("except InvalidFieldValue as inner:"):
             self.lines.append(
-                f"path = '{field_name}' + '.' + inner.path if inner.path else '{field_name}'"
+                f"path = '{field_name}' + '.' + inner.path "
+                f"if inner.path else '{field_name}'"
             )
             self.lines.append(
                 "raise InvalidFieldValue("

--- a/mashumaro/core/meta/code/builder.py
+++ b/mashumaro/core/meta/code/builder.py
@@ -1246,7 +1246,25 @@ class FieldUnpackerCodeBlockBuilder:
     ) -> None:
         with self.lines.indent("try:"):
             self._set_value(field_name, unpacked_value, in_kwargs)
-        with self.lines.indent("except:"):
+        with self.lines.indent("except MissingField as inner:"):
+            self.lines.append(
+                f"path = '{field_name}' + '.' + inner.path if inner.path else '{field_name}'"
+            )
+            self.lines.append(
+                "raise MissingField("
+                "inner.field_name,inner.field_type,"
+                "inner.holder_class,path) from None"
+            )
+        with self.lines.indent("except InvalidFieldValue as inner:"):
+            self.lines.append(
+                f"path = '{field_name}' + '.' + inner.path if inner.path else '{field_name}'"
+            )
+            self.lines.append(
+                "raise InvalidFieldValue("
+                "inner.field_name,inner.field_type,inner.field_value,"
+                "inner.holder_class,inner.msg,path) from None"
+            )
+        with self.lines.indent("except Exception:"):
             self.lines.append(
                 "raise InvalidFieldValue("
                 f"'{field_name}',{field_type_name},value,cls)"

--- a/mashumaro/core/meta/code/builder.py
+++ b/mashumaro/core/meta/code/builder.py
@@ -451,6 +451,13 @@ class CodeBuilder:
                 if config.forbid_extra_keys:
                     allowed_keys = {f[1] or f[0] for f in filtered_fields}
 
+                    # If a discirimator withg a field is set via config,
+                    # we should allow this field to be present in the input
+                    # This will not work for annotated discriminators though...
+                    discr = self.get_config(look_in_parents=True).discriminator
+                    if discr and discr.field:
+                        allowed_keys.add(discr.field)
+
                     if config.allow_deserialization_not_by_alias:
                         allowed_keys |= {f[0] for f in filtered_fields}
 

--- a/mashumaro/exceptions.py
+++ b/mashumaro/exceptions.py
@@ -43,7 +43,10 @@ class ExtraKeysError(ValueError):
 
     def __str__(self) -> str:
         extra_keys_str = ", ".join(k for k in self.extra_keys)
-        return f"Serialized dict has keys that are not defined in {self.target_class_name}: {extra_keys_str}"
+        return (
+            "Serialized dict has keys that are not defined in "
+            f"{self.target_class_name}: {extra_keys_str}"
+        )
 
 
 class UnserializableDataError(TypeError):

--- a/mashumaro/exceptions.py
+++ b/mashumaro/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Type
+from typing import Any, Optional, Set, Type
 
 from mashumaro.core.meta.helpers import type_name
 
@@ -22,6 +22,20 @@ class MissingField(LookupError):
             f'Field "{self.field_name}" of type {self.field_type_name}'
             f" is missing in {self.holder_class_name} instance"
         )
+
+
+class ExtraKeysError(ValueError):
+    def __init__(self, extra_keys: Set[str], target_type: Type):
+        self.extra_keys = extra_keys
+        self.target_type = target_type
+
+    @property
+    def target_class_name(self) -> str:
+        return type_name(self.target_type, short=True)
+
+    def __str__(self) -> str:
+        extra_keys_str = ", ".join(k for k in self.extra_keys)
+        return f"Serialized dict has keys that are not defined in {self.target_class_name}: {extra_keys_str}"
 
 
 class UnserializableDataError(TypeError):

--- a/mashumaro/exceptions.py
+++ b/mashumaro/exceptions.py
@@ -4,10 +4,17 @@ from mashumaro.core.meta.helpers import type_name
 
 
 class MissingField(LookupError):
-    def __init__(self, field_name: str, field_type: Type, holder_class: Type):
+    def __init__(
+        self,
+        field_name: str,
+        field_type: Type,
+        holder_class: Type,
+        path: Optional[str] = None,
+    ):
         self.field_name = field_name
         self.field_type = field_type
         self.holder_class = holder_class
+        self.path = path
 
     @property
     def field_type_name(self) -> str:
@@ -18,8 +25,9 @@ class MissingField(LookupError):
         return type_name(self.holder_class, short=True)
 
     def __str__(self) -> str:
+        path = f' at path "{self.path}"' if self.path else ""
         return (
-            f'Field "{self.field_name}" of type {self.field_type_name}'
+            f'Field "{self.field_name}"{path} of type {self.field_type_name}'
             f" is missing in {self.holder_class_name} instance"
         )
 
@@ -113,12 +121,14 @@ class InvalidFieldValue(ValueError):
         field_value: Any,
         holder_class: Type,
         msg: Optional[str] = None,
+        path: Optional[str] = None,
     ):
         self.field_name = field_name
         self.field_type = field_type
         self.field_value = field_value
         self.holder_class = holder_class
         self.msg = msg
+        self.path = path
 
     @property
     def field_type_name(self) -> str:
@@ -129,8 +139,9 @@ class InvalidFieldValue(ValueError):
         return type_name(self.holder_class, short=True)
 
     def __str__(self) -> str:
+        path = f' at path "{self.path}"' if self.path else ""
         s = (
-            f'Field "{self.field_name}" of type {self.field_type_name} '
+            f'Field "{self.field_name}"{path} of type {self.field_type_name} '
             f"in {self.holder_class_name} has invalid value "
             f"{repr(self.field_value)}"
         )

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1009,13 +1009,16 @@ def test_invalid_field_value_deserialization_with_rounded_decimal_with_default()
     with pytest.raises(InvalidFieldValue):
         DataClass.from_dict({"x": "bad_value"})
 
+
 @dataclass
 class _InnerDeserializeTest(DataClassDictMixin):
     x: int
 
+
 @dataclass
 class _MiddleDeserializeTest(DataClassDictMixin):
     inner: _InnerDeserializeTest
+
 
 def test_invalid_nested_field_value_deserialization():
     @dataclass
@@ -1030,6 +1033,7 @@ def test_invalid_nested_field_value_deserialization():
     assert exc_info.value.holder_class == _InnerDeserializeTest
     assert exc_info.value.field_value == "bad_value"
     assert exc_info.value.path == "middle.inner"
+
 
 def test_missing_nested_field_value_deserialization():
     @dataclass


### PR DESCRIPTION
Hi,

This does two things:

* Mostly implements #136 (see below)
* Adds a new config option `forbid_extra_keys`, that, well, checks for extra keys during deserialization and fails with a new exception.

Caveats:

* The codecs code is pretty dense, I've tried to understand it without the comments, but do not feel confident enough to apply any changes there => the new features may or may not work for codecs
* I dropped the ball on implementing the full path for sequences. I do not think that their going to be any noticeable performance penalty to track current sequence index, but to implement it, the whole `unpack_collection` must change from an expression generator to a full sub-builder. That's a bit too much for my time constraints;-)

I'd love this to be merged though. I think it adds quite a lot of value already.

Let me know what you think!