### PR TITLE
Improve union encoding performance

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,7 +32,7 @@ def test_debug_true_option(mocker):
 
     @dataclass
     class _(DataClassDictMixin):
-        union: Union[int, str]
+        union: Union[int, str, MyNamedTuple]
         typed_dict: TypedDictRequiredKeys
         named_tuple: MyNamedTupleWithDefaults
         literal: Literal[1, 2, 3]

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1467,9 +1467,6 @@ def test_dataclass_with_non_optional_none_value():
     assert DataClass.from_dict({"x": 42}) == obj
     assert obj.to_dict() == {"x": 42, "y": None, "z": 42}
 
-    with pytest.raises(TypeError):
-        DataClass(x=42, z=None).to_dict()
-
 
 def test_dataclass_with_optional_list_with_optional_ints():
     @dataclass

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -1,9 +1,12 @@
 from dataclasses import dataclass
+from itertools import permutations
 from typing import Any, Dict, List, Union
 
 import pytest
 
 from mashumaro import DataClassDictMixin
+from mashumaro.codecs.basic import encode
+from tests.utils import same_types
 
 
 @dataclass
@@ -32,3 +35,12 @@ def test_union(test_case):
     instance = DataClass(x=test_case.loaded)
     assert DataClass.from_dict({"x": test_case.dumped}) == instance
     assert instance.to_dict() == {"x": test_case.dumped}
+
+
+def test_union_encoding():
+    for variants in permutations((int, float, str, bool)):
+        for value in (1, 2.0, 3.1, "4", "5.0", True, False):
+            encoded = encode(value, Union[*variants])
+            assert value == encoded
+            assert same_types(value, encoded)
+            print(value)

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -40,7 +40,6 @@ def test_union(test_case):
 def test_union_encoding():
     for variants in permutations((int, float, str, bool)):
         for value in (1, 2.0, 3.1, "4", "5.0", True, False):
-            encoded = encode(value, Union[*variants])
+            encoded = encode(value, Union[variants])
             assert value == encoded
             assert same_types(value, encoded)
-            print(value)


### PR DESCRIPTION
Currently, we have to wrap `int` and `float` values on serialization with `int(...)` and `float(...)`. This is used as a hack for poor union serialization logic which is based on applying an encoding operation for each type in the list until we get the first result without errors. If we have a value of type `Union[int, DataClassA]` then without applying `int(value)` (which will obviously fail on instances of `DataClassA`) we would pass instances of `DataClassA` as is because `int` is on the first place.

In this PR union serialization logic is changed so that we check the type of a value with pass-through strategy before returning it as is. It allows us to remove a hack for `int` and `float` and not try to perform encoding operations that are known to fail.

This pull request fixes the following issues:
* https://github.com/Fatal1ty/mashumaro/issues/190