### PR TITLE
Fix type substitution in Annotated on Python 3.13

### DIFF
--- a/mashumaro/core/meta/helpers.py
+++ b/mashumaro/core/meta/helpers.py
@@ -629,9 +629,9 @@ def substitute_type_params(typ: Type, substitutions: Dict[Type, Type]) -> Type:
     if is_annotated(typ):
         origin = get_type_origin(typ)
         subst = substitutions.get(origin, origin)
-        return typing_extensions.Annotated.__class_getitem__(  # type: ignore
-            (subst, *get_type_annotations(typ))
-        )
+        return typing_extensions.Annotated[
+            (subst, *get_type_annotations(typ))  # type: ignore
+        ]
     else:
         new_type_args = []
         for type_param in collect_type_params(typ):


### PR DESCRIPTION
Implementation of `Annotated` on Python 3.13 was changed and broke our type substitution:
* https://github.com/python/cpython/pull/105510

This PR simplifies type substitution in `Annotated` to work on all Python versions.