### PR TITLE
Skip tests with orjson and pendulum on Python 3.13

### DIFF
--- a/mashumaro/core/const.py
+++ b/mashumaro/core/const.py
@@ -9,6 +9,7 @@ __all__ = [
     "PY_310_MIN",
     "PY_311_MIN",
     "PY_312_MIN",
+    "PY_313_MIN",
     "PEP_585_COMPATIBLE",
     "Sentinel",
 ]
@@ -18,8 +19,10 @@ PY_38 = sys.version_info.major == 3 and sys.version_info.minor == 8
 PY_39 = sys.version_info.major == 3 and sys.version_info.minor == 9
 PY_310 = sys.version_info.major == 3 and sys.version_info.minor == 10
 PY_311 = sys.version_info.major == 3 and sys.version_info.minor == 11
-PY_312_MIN = sys.version_info.major == 3 and sys.version_info.minor >= 12
+PY_312 = sys.version_info.major == 3 and sys.version_info.minor == 12
+PY_313_MIN = sys.version_info.major == 3 and sys.version_info.minor >= 13
 
+PY_312_MIN = PY_312 or PY_313_MIN
 PY_311_MIN = PY_311 or PY_312_MIN
 PY_310_MIN = PY_310 or PY_311_MIN
 PY_39_MIN = PY_39 or PY_310_MIN

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ msgpack>=0.5.6
 pyyaml>=3.13
 tomli-w>=1.0
 tomli>=1.1.0;python_version<'3.11'
-orjson>=3.6.1
+orjson>=3.6.1;python_version<'3.13'
 
 # tests
 mypy>=0.812
@@ -18,7 +18,7 @@ codespell>=2.2.2
 
 # third party features
 ciso8601>=2.1.3
-pendulum>=2.1.2
+pendulum>=2.1.2;python_version<'3.13'
 
 # benchmark
 pyperf>=2.6.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,16 @@
 from unittest.mock import patch
 
+from mashumaro.core.const import PY_313_MIN
+
+if PY_313_MIN:
+    collect_ignore = [
+        "test_codecs/test_orjson_codec.py",
+        "test_discriminated_unions/test_dialects.py",
+        "test_orjson.py",
+        "test_pep_563.py",
+        "test_self.py",
+    ]
+
 add_unpack_method = patch(
     "mashumaro.core.meta.code.builder.CodeBuilder.add_unpack_method",
     lambda *args, **kwargs: ...,

--- a/tests/test_metadata_options.py
+++ b/tests/test_metadata_options.py
@@ -7,7 +7,7 @@ import ciso8601
 import pytest
 
 from mashumaro import DataClassDictMixin
-from mashumaro.core.const import PY_312_MIN
+from mashumaro.core.const import PY_312_MIN, PY_313_MIN
 from mashumaro.exceptions import (
     UnserializableField,
     UnsupportedDeserializationEngine,
@@ -58,6 +58,7 @@ def test_ciso8601_time_parser():
     assert instance == should_be
 
 
+@pytest.mark.skipif(PY_313_MIN, reason="pendulum doesn't install on 3.13")
 def test_pendulum_datetime_parser():
     @dataclass
     class DataClass(DataClassDictMixin):
@@ -68,6 +69,7 @@ def test_pendulum_datetime_parser():
     assert instance == should_be
 
 
+@pytest.mark.skipif(PY_313_MIN, reason="pendulum doesn't install on 3.13")
 def test_pendulum_date_parser():
     @dataclass
     class DataClass(DataClassDictMixin):
@@ -78,6 +80,7 @@ def test_pendulum_date_parser():
     assert instance == should_be
 
 
+@pytest.mark.skipif(PY_313_MIN, reason="pendulum doesn't install on 3.13")
 def test_pendulum_time_parser():
     @dataclass
     class DataClass(DataClassDictMixin):


### PR DESCRIPTION
Orson and pendulum don't install on Python 3.13, so we exclude them from tests for now.