### PR TITLE
Add support for MappingProxyType

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ for special primitives from the [`typing`](https://docs.python.org/3/library/typ
 for standard interpreter types from [`types`](https://docs.python.org/3/library/types.html#standard-interpreter-types) module:
 * [`NoneType`](https://docs.python.org/3/library/types.html#types.NoneType)
 * [`UnionType`](https://docs.python.org/3/library/types.html#types.UnionType)
+* [`MappingProxyType`](https://docs.python.org/3/library/types.html#types.MappingProxyType)
 
 for enumerations based on classes from the standard [`enum`](https://docs.python.org/3/library/enum.html) module:
 * [`Enum`](https://docs.python.org/3/library/enum.html#enum.Enum)

--- a/mashumaro/core/meta/types/unpack.py
+++ b/mashumaro/core/meta/types/unpack.py
@@ -1230,6 +1230,12 @@ def unpack_collection(spec: ValueSpec) -> Optional[Expression]:
         )
     elif is_typed_dict(spec.origin_type):
         return unpack_typed_dict(spec)
+    elif issubclass(spec.origin_type, types.MappingProxyType):
+        spec.builder.ensure_module_imported(types)
+        return (
+            f'types.MappingProxyType({{{inner_expr(0, "key")}: {inner_expr(1)}'
+            f" for key, value in {spec.expression}.items()}})"
+        )
     elif ensure_generic_mapping(spec, args, typing.Mapping):
         return (
             f'{{{inner_expr(0, "key")}: {inner_expr(1)} '

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -206,8 +206,6 @@ inner_values = [
     (OrderedDict, Fixture.ORDERED_DICT, Fixture.DICT),
     (DefaultDict[str, int], Fixture.DEFAULT_DICT, Fixture.DICT),
     (DefaultDict, Fixture.DEFAULT_NONE_DICT, Fixture.DICT),
-    (MappingProxyType[str, int], Fixture.MAPPING_PROXY, Fixture.DICT),
-    (MappingProxyType, Fixture.MAPPING_PROXY, Fixture.DICT),
     (Counter[str], Fixture.COUNTER, Fixture.DICT),
     (Counter, Fixture.COUNTER, Fixture.DICT),
     (MutableMapping[str, int], Fixture.DICT, Fixture.DICT),
@@ -338,7 +336,13 @@ if PEP_585_COMPATIBLE:
     )
 
 if PY_39_MIN:
-    inner_values.append((ZoneInfo, ZoneInfo("Europe/Moscow"), "Europe/Moscow"))
+    inner_values.extend(
+        (
+            (ZoneInfo, ZoneInfo("Europe/Moscow"), "Europe/Moscow"),
+            (MappingProxyType[str, int], Fixture.MAPPING_PROXY, Fixture.DICT),
+            (MappingProxyType, Fixture.MAPPING_PROXY, Fixture.DICT),
+        )
+    )
 
 
 hashable_inner_values = [

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -16,6 +16,7 @@ from pathlib import (
     WindowsPath,
 )
 from queue import Queue
+from types import MappingProxyType
 from typing import (
     Any,
     AnyStr,
@@ -123,6 +124,7 @@ class Fixture:
     DICT = {"a": 1, "b": 2}
     ORDERED_DICT = collections.OrderedDict(a=1, b=2)
     DEFAULT_DICT = collections.defaultdict(int, a=1, b=2)
+    MAPPING_PROXY = MappingProxyType(DICT)
     DEFAULT_NONE_DICT = collections.defaultdict(None, a=1, b=2)
     COUNTER: Counter[str] = collections.Counter(a=1, b=2)
     BYTES = b"123"
@@ -204,6 +206,8 @@ inner_values = [
     (OrderedDict, Fixture.ORDERED_DICT, Fixture.DICT),
     (DefaultDict[str, int], Fixture.DEFAULT_DICT, Fixture.DICT),
     (DefaultDict, Fixture.DEFAULT_NONE_DICT, Fixture.DICT),
+    (MappingProxyType[str, int], Fixture.MAPPING_PROXY, Fixture.DICT),
+    (MappingProxyType, Fixture.MAPPING_PROXY, Fixture.DICT),
     (Counter[str], Fixture.COUNTER, Fixture.DICT),
     (Counter, Fixture.COUNTER, Fixture.DICT),
     (MutableMapping[str, int], Fixture.DICT, Fixture.DICT),

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,5 +1,6 @@
 import collections
 import collections.abc
+import types
 import typing
 from dataclasses import InitVar, dataclass
 from datetime import datetime
@@ -216,6 +217,9 @@ def test_type_name():
         type_name(typing.DefaultDict[int, int])
         == "typing.DefaultDict[int, int]"
     )
+    assert (
+        type_name(types.MappingProxyType[int, int]) == "mappingproxy[int, int]"
+    )
     assert type_name(typing.Optional[int]) == "typing.Optional[int]"
     assert type_name(typing.Union[None, int]) == "typing.Optional[int]"
     assert type_name(typing.Union[int, None]) == "typing.Optional[int]"
@@ -307,6 +311,10 @@ def test_type_name_short():
     assert (
         type_name(typing.MutableMapping[int, int], short=True)
         == "MutableMapping[int, int]"
+    )
+    assert (
+        type_name(types.MappingProxyType[int, int], short=True)
+        == "mappingproxy[int, int]"
     )
     assert type_name(typing.Counter[int], short=True) == "Counter[int]"
     assert (

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -9,7 +9,12 @@ import pytest
 import typing_extensions
 
 from mashumaro import DataClassDictMixin
-from mashumaro.core.const import PEP_585_COMPATIBLE, PY_38, PY_310_MIN
+from mashumaro.core.const import (
+    PEP_585_COMPATIBLE,
+    PY_38,
+    PY_39_MIN,
+    PY_310_MIN,
+)
 from mashumaro.core.meta.code.builder import CodeBuilder
 
 # noinspection PyProtectedMember
@@ -217,9 +222,6 @@ def test_type_name():
         type_name(typing.DefaultDict[int, int])
         == "typing.DefaultDict[int, int]"
     )
-    assert (
-        type_name(types.MappingProxyType[int, int]) == "mappingproxy[int, int]"
-    )
     assert type_name(typing.Optional[int]) == "typing.Optional[int]"
     assert type_name(typing.Union[None, int]) == "typing.Optional[int]"
     assert type_name(typing.Union[int, None]) == "typing.Optional[int]"
@@ -233,6 +235,11 @@ def test_type_name():
     )
     assert type_name(typing.Optional[NoneType]) == "NoneType"
 
+    if PY_39_MIN:
+        assert (
+            type_name(types.MappingProxyType[int, int])
+            == "mappingproxy[int, int]"
+        )
     if PY_310_MIN:
         assert type_name(int | None) == "typing.Optional[int]"
         assert type_name(None | int) == "typing.Optional[int]"
@@ -312,10 +319,6 @@ def test_type_name_short():
         type_name(typing.MutableMapping[int, int], short=True)
         == "MutableMapping[int, int]"
     )
-    assert (
-        type_name(types.MappingProxyType[int, int], short=True)
-        == "mappingproxy[int, int]"
-    )
     assert type_name(typing.Counter[int], short=True) == "Counter[int]"
     assert (
         type_name(typing.ChainMap[int, int], short=True)
@@ -348,6 +351,11 @@ def test_type_name_short():
     )
     assert type_name(typing.Optional[NoneType], short=True) == "NoneType"
 
+    if PY_39_MIN:
+        assert (
+            type_name(types.MappingProxyType[int, int], short=True)
+            == "mappingproxy[int, int]"
+        )
     if PY_310_MIN:
         assert type_name(int | None, short=True) == "Optional[int]"
         assert type_name(None | int, short=True) == "Optional[int]"


### PR DESCRIPTION
This adds support for `types.MappingProxyType`:

```python
from types import MappingProxyType

from mashumaro.codecs import BasicDecoder, BasicEncoder


decoder = BasicDecoder(MappingProxyType[int, float])
encoder = BasicEncoder(MappingProxyType[int, float])

assert repr(decoder.decode({"42": "42"})) == "mappingproxy({42: 42.0})"
assert encoder.encode(MappingProxyType({42: 42.0})) == {42: 42.0}
```

```python
from dataclasses import dataclass
from types import MappingProxyType

from mashumaro import DataClassDictMixin


@dataclass
class MyClass(DataClassDictMixin):
    x: MappingProxyType[int, float]

obj = MyClass.from_dict({"x": {"42": "42"}})
assert repr(obj) == "MyClass(x=mappingproxy({42: 42.0}))"
assert repr(obj.to_dict()) == "{'x': {42: 42.0}}"
```