### PR TITLE
Add array_like (de)serialization for dataclasses

### DIFF
--- a/mashumaro/config.py
+++ b/mashumaro/config.py
@@ -70,3 +70,4 @@ class BaseConfig:
     sort_keys: bool = False
     allow_deserialization_not_by_alias: bool = False
     forbid_extra_keys: bool = False
+    array_like: bool = False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -386,6 +386,35 @@ def test_forbid_extra_keys():
     assert exc_info.value.extra_keys == {"baz"}
     assert exc_info.value.target_type == ForbidKeysModel
 
+def test_array_like():
+    @dataclass
+    class FooModel(DataClassDictMixin):
+        foo: int
+
+        class Config(BaseConfig):
+            array_like = True
+
+    # Test packing works
+    assert FooModel(1).to_dict() == (1,)
+
+    # Test unpacking works
+    assert FooModel.from_dict((1,)) == FooModel(1)
+
+    # Nested
+    @dataclass
+    class BarModel(DataClassDictMixin):
+        bar: str
+        inner: FooModel
+
+        class Config(BaseConfig):
+            array_like = True
+
+    # Test packing works
+    assert BarModel("bar", FooModel(1)).to_dict() == ("bar", (1,))
+
+    # Test unpacking works
+    assert BarModel.from_dict(("bar", (1,))) == BarModel("bar", FooModel(1))
+
 
 @dataclass
 class _VariantByBase(DataClassDictMixin):


### PR DESCRIPTION
Hi!

Wanted to float an idea of adding "array_like" serialization format for data classes. Essentially the same as [this msgspec feature](https://jcristharif.com/msgspec/structs.html#encoding-decoding-as-arrays).

As of time of writing this is just a POC, see [this single new test](https://github.com/mishamsk/mashumaro/blob/array-like-serialization-for-dataclasses/tests/test_config.py#L389) for a sample.

Such an option will be a big size reduction/performance boost, but the interaction with other options will be pretty tricky. At least the discrimination and defaults handling will have to be carefully handled. Some configuration combinations will have to be forbidden (e.g. skipping defaults with array_like enabled).

Wanted to get some feedback early before doing the entire thing, hence opening PR so early.