### PR TITLE
Canonical type comparison

### DIFF
--- a/mashumaro/core/meta/types/pack.py
+++ b/mashumaro/core/meta/types/pack.py
@@ -251,7 +251,7 @@ def pack_dataclass(spec: ValueSpec) -> Optional[Expression]:
         if get_class_that_defines_method(
             method_name, method_loc
         ) != method_loc and (
-            spec.origin_type != spec.builder.cls
+            spec.origin_type is not spec.builder.cls
             or spec.builder.get_pack_method_name(
                 type_args=type_args,
                 format_name=spec.builder.format_name,

--- a/mashumaro/core/meta/types/unpack.py
+++ b/mashumaro/core/meta/types/unpack.py
@@ -665,7 +665,7 @@ def unpack_dataclass(spec: ValueSpec) -> Optional[Expression]:
         if get_class_that_defines_method(
             method_name, method_loc
         ) != method_loc and (
-            spec.origin_type != spec.builder.cls
+            spec.origin_type is not spec.builder.cls
             or spec.builder.get_unpack_method_name(
                 type_args=type_args,
                 format_name=spec.builder.format_name,


### PR DESCRIPTION
Type comparisons are recommended to be done using `isinstance` or `is` and not `==`.
This PR fixes that.