### PR TITLE
Fix Python 3.13 DeprecationWarning

### DIFF
--- a/mashumaro/core/meta/helpers.py
+++ b/mashumaro/core/meta/helpers.py
@@ -38,6 +38,7 @@ from mashumaro.core.const import (
     PY_310_MIN,
     PY_311_MIN,
     PY_312_MIN,
+    PY_313_MIN,
 )
 from mashumaro.dialect import Dialect
 
@@ -772,7 +773,11 @@ def str_to_forward_ref(
 def evaluate_forward_ref(
     typ: ForwardRef, globalns: Dict[str, Any], localns: Dict[str, Any]
 ) -> Optional[Type]:
-    if PY_39_MIN:
+    if PY_313_MIN:
+        return typ._evaluate(
+            globalns, localns, type_params=(), recursive_guard=frozenset()
+        )  # type: ignore[call-arg]
+    elif PY_39_MIN:
         return typ._evaluate(
             globalns, localns, recursive_guard=frozenset()
         )  # type: ignore[call-arg]


### PR DESCRIPTION
```
/.../mashumaro/mashumaro/core/meta/helpers.py:776: DeprecationWarning:
    Failing to pass a value to the 'type_params' parameter of 'typing.ForwardRef._evaluate' is deprecated,
    as it leads to incorrect behaviour when calling typing.ForwardRef._evaluate on a stringified annotation
    that references a PEP 695 type parameter. It will be disallowed in Python 3.15.
  return typ._evaluate(
```