### PR TITLE
Make Union deserialization algorithm more robust

### DIFF
--- a/benchmark/libs/mashumaro/common.py
+++ b/benchmark/libs/mashumaro/common.py
@@ -6,17 +6,13 @@ from typing import Optional, Union
 import pyperf
 
 from benchmark.common import AbstractBenchmark
-from mashumaro import field_options, pass_through
+from mashumaro import field_options
 from mashumaro.codecs import BasicDecoder, BasicEncoder
 from mashumaro.dialect import Dialect
 
 
 class DefaultDialect(Dialect):
     serialize_by_alias = True
-    serialization_strategy = {
-        str: {"deserialize": str, "serialize": pass_through},
-        int: {"serialize": pass_through},
-    }
 
 
 class IssueState(Enum):

--- a/mashumaro/core/meta/code/builder.py
+++ b/mashumaro/core/meta/code/builder.py
@@ -487,7 +487,7 @@ class CodeBuilder:
                         self.add_type_modules(ftype)
                         metadata = self.metadatas.get(fname, {})
                         field_block = FieldUnpackerCodeBlockBuilder(
-                            self, self.lines.branch_off()
+                            self, CodeLines()
                         ).build(
                             fname=fname,
                             ftype=ftype,

--- a/mashumaro/core/meta/code/lines.py
+++ b/mashumaro/core/meta/code/lines.py
@@ -13,7 +13,8 @@ class CodeLines:
         self._lines.append(f"{self._current_indent}{line}")
 
     def extend(self, lines: "CodeLines") -> None:
-        self._lines.extend(lines._lines)
+        for line in lines._lines:
+            self._lines.append(f"{self._current_indent}{line}")
 
     @contextmanager
     def indent(
@@ -34,8 +35,3 @@ class CodeLines:
     def reset(self) -> None:
         self._lines = []
         self._current_indent = ""
-
-    def branch_off(self) -> "CodeLines":
-        branch = CodeLines()
-        branch._current_indent = self._current_indent
-        return branch

--- a/mashumaro/core/meta/types/common.py
+++ b/mashumaro/core/meta/types/common.py
@@ -16,6 +16,7 @@ from typing import (
     Sequence,
     Type,
     TypeVar,
+    Union,
 )
 
 from typing_extensions import ParamSpec, TypeAlias
@@ -39,8 +40,12 @@ else:
     CodeBuilder = Any
 
 
+class TypeMatchEligibleExpression(str):
+    pass
+
+
 NoneType = type(None)
-Expression: TypeAlias = str
+Expression: TypeAlias = Union[str, TypeMatchEligibleExpression]
 
 P = ParamSpec("P")
 T = TypeVar("T")

--- a/mashumaro/core/meta/types/unpack.py
+++ b/mashumaro/core/meta/types/unpack.py
@@ -183,7 +183,8 @@ class UnionUnpackerBuilder(AbstractUnpackerBuilder):
             if isinstance(unpacker, TypeMatchEligibleExpression):
                 do_try = False
                 condition = f"type(value) is {type_arg.__name__}"
-                if (condition, unpacker) in unpackers:
+                if (condition, unpacker) in unpackers:  # pragma: no cover
+                    # we shouldn't be here because condition is always unique
                     continue
                 with unpacker_block.indent(f"if {condition}:"):
                     unpacker_block.append("return value")

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -1,10 +1,12 @@
 from dataclasses import dataclass, field
+from email.policy import default
+from importlib.metadata import metadata
 from typing import Optional
 
 import pytest
 from typing_extensions import Annotated
 
-from mashumaro import DataClassDictMixin
+from mashumaro import DataClassDictMixin, pass_through
 from mashumaro.config import (
     TO_DICT_ADD_BY_ALIAS_FLAG,
     TO_DICT_ADD_OMIT_NONE_FLAG,
@@ -233,34 +235,74 @@ def test_by_field_with_allow_deserialization_not_by_alias():
         b2: Annotated[Optional[int], Alias("alias_b2")]
         c1: Optional[str] = field(metadata={"alias": "alias_c1"})
         c2: Annotated[Optional[str], Alias("alias_c2")]
-        d1: int = field(metadata={"alias": "alias_d1"}, default=4)
-        d2: Annotated[int, Alias("alias_d2")] = 4
-        e1: Optional[int] = field(metadata={"alias": "alias_e1"}, default=5)
-        e2: Annotated[Optional[int], Alias("alias_e2")] = 5
-        f1: Optional[str] = field(metadata={"alias": "alias_f1"}, default="6")
-        f2: Annotated[Optional[str], Alias("alias_f2")] = "6"
+        d1: int = field(
+            metadata={"alias": "alias_d1", "deserialize": pass_through}
+        )
+        d2: Annotated[int, Alias("alias_d2")] = field(
+            metadata={"deserialize": pass_through}
+        )
+        e1: int = field(metadata={"alias": "alias_e1"}, default=5)
+        e2: Annotated[int, Alias("alias_e2")] = 5
+        f1: Optional[int] = field(metadata={"alias": "alias_f1"}, default=6)
+        f2: Annotated[Optional[int], Alias("alias_f2")] = 6
+        g1: Optional[str] = field(metadata={"alias": "alias_g1"}, default="7")
+        g2: Annotated[Optional[str], Alias("alias_g2")] = "7"
+        h1: int = field(
+            metadata={"alias": "alias_h1", "deserialize": pass_through},
+            default=8,
+        )
+        h2: Annotated[int, Alias("alias_h2")] = field(
+            metadata={"deserialize": pass_through}, default=8
+        )
 
         class Config(BaseConfig):
             serialize_by_alias = True
             code_generation_options = [TO_DICT_ADD_BY_ALIAS_FLAG]
             allow_deserialization_not_by_alias = True
 
-    instance = DataClass(a1=1, a2=1, b1=2, b2=2, c1="3", c2="3")
+    instance = DataClass(a1=1, a2=1, b1=2, b2=2, c1="3", c2="3", d1=4, d2=4)
     assert (
         DataClass.from_dict(
             {
                 "a1": 1,
                 "a2": 1,
-                "alias_b1": 2,
-                "alias_b2": 2,
+                "b1": 2,
+                "b2": 2,
                 "c1": "3",
                 "c2": "3",
-                "alias_d1": 4,
-                "alias_d2": 4,
+                "d1": 4,
+                "d2": 4,
                 "e1": 5,
                 "e2": 5,
-                "alias_f1": "6",
-                "alias_f2": "6",
+                "f1": 6,
+                "f2": 6,
+                "g1": "7",
+                "g2": "7",
+                "h1": 8,
+                "h2": 8,
+            }
+        )
+        == instance
+    )
+    assert (
+        DataClass.from_dict(
+            {
+                "alias_a1": 1,
+                "alias_a2": 1,
+                "alias_b1": 2,
+                "alias_b2": 2,
+                "alias_c1": "3",
+                "alias_c2": "3",
+                "alias_d1": 4,
+                "alias_d2": 4,
+                "alias_e1": 5,
+                "alias_e2": 5,
+                "alias_f1": 6,
+                "alias_f2": 6,
+                "alias_g1": "7",
+                "alias_g2": "7",
+                "alias_h1": 8,
+                "alias_h2": 8,
             }
         )
         == instance
@@ -276,8 +318,12 @@ def test_by_field_with_allow_deserialization_not_by_alias():
         "alias_d2": 4,
         "alias_e1": 5,
         "alias_e2": 5,
-        "alias_f1": "6",
-        "alias_f2": "6",
+        "alias_f1": 6,
+        "alias_f2": 6,
+        "alias_g1": "7",
+        "alias_g2": "7",
+        "alias_h1": 8,
+        "alias_h2": 8,
     }
     assert instance.to_dict(by_alias=False) == {
         "a1": 1,
@@ -290,8 +336,12 @@ def test_by_field_with_allow_deserialization_not_by_alias():
         "d2": 4,
         "e1": 5,
         "e2": 5,
-        "f1": "6",
-        "f2": "6",
+        "f1": 6,
+        "f2": 6,
+        "g1": "7",
+        "g2": "7",
+        "h1": 8,
+        "h2": 8,
     }
 
 

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1304,6 +1304,7 @@ def test_data_class_with_none():
 
     obj = DataClass(x=None, y=None, z=[None])
     assert DataClass.from_dict({"x": None, "y": None, "z": [None]}) == obj
+    assert DataClass.from_dict({"x": 42, "y": "foo", "z": ["bar"]}) == obj
     assert obj.to_dict() == {"x": None, "y": None, "z": [None]}
 
 

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import date
 from itertools import permutations
 from typing import Any, Dict, List, Union
 
@@ -19,7 +20,101 @@ class UnionTestCase:
 @pytest.mark.parametrize(
     "test_case",
     [
+        # int | str
         UnionTestCase(Union[int, str], 1, 1),
+        UnionTestCase(Union[int, str], "1", "1"),
+        UnionTestCase(Union[int, str], 1.0, 1),
+        UnionTestCase(Union[int, str], 1.2, 1),
+        UnionTestCase(Union[int, str], "a", "a"),
+        UnionTestCase(Union[int, str], [1, 2], "[1, 2]"),
+        # str | int
+        UnionTestCase(Union[str, int], 1, 1),
+        UnionTestCase(Union[str, int], "1", "1"),
+        UnionTestCase(Union[str, int], 1.0, "1.0"),
+        UnionTestCase(Union[str, int], 1.2, "1.2"),
+        UnionTestCase(Union[str, int], "a", "a"),
+        UnionTestCase(Union[str, int], [1, 2], "[1, 2]"),
+        # str | date
+        UnionTestCase(Union[str, date], "2024-11-12", "2024-11-12"),
+        UnionTestCase(Union[str, date], "a", "a"),
+        # date | str
+        UnionTestCase(Union[date, str], "2024-11-12", date(2024, 11, 12)),
+        UnionTestCase(Union[date, str], "a", "a"),
+        # int | float
+        UnionTestCase(Union[int, float], 1, 1),
+        UnionTestCase(Union[int, float], 1.0, 1.0),
+        UnionTestCase(Union[int, float], "1", 1),
+        UnionTestCase(Union[int, float], "1.0", 1.0),
+        # float | int
+        UnionTestCase(Union[float, int], 1, 1),
+        UnionTestCase(Union[float, int], 1.0, 1.0),
+        UnionTestCase(Union[float, int], "1", 1.0),
+        UnionTestCase(Union[float, int], "1.0", 1.0),
+        # bool | int
+        UnionTestCase(Union[bool, int], 1, 1),
+        UnionTestCase(Union[bool, int], 1.0, True),
+        UnionTestCase(Union[bool, int], True, True),
+        UnionTestCase(Union[bool, int], "1", True),
+        UnionTestCase(Union[bool, int], "1.2", True),
+        UnionTestCase(Union[bool, int], [1, 2], True),
+        UnionTestCase(Union[bool, int], "a", True),
+        # int | bool
+        UnionTestCase(Union[int, bool], 1, 1),
+        UnionTestCase(Union[int, bool], 1.0, 1),
+        UnionTestCase(Union[int, bool], True, True),
+        UnionTestCase(Union[int, bool], "1", 1),
+        UnionTestCase(Union[int, bool], "1.2", True),
+        UnionTestCase(Union[int, bool], [1, 2], True),
+        UnionTestCase(Union[int, bool], "a", True),
+        # dict[int, int] | list[int]
+        UnionTestCase(Union[Dict[int, int], List[int]], {1: 2}, {1: 2}),
+        UnionTestCase(Union[Dict[int, int], List[int]], {"1": "2"}, {1: 2}),
+        UnionTestCase(Union[Dict[int, int], List[int]], [1], [1]),
+        UnionTestCase(Union[Dict[int, int], List[int]], ["1"], [1]),
+        # str | list[str]
+        UnionTestCase(Union[str, List[str]], ["a"], ["a"]),
+        UnionTestCase(Union[str, List[str]], "abc", "abc"),
+        UnionTestCase(Union[str, List[str]], 1, "1"),
+        UnionTestCase(Union[str, List[str]], [1, 2], ["1", "2"]),
+        # int | float | None
+        UnionTestCase(Union[int, float, None], None, None),
+        UnionTestCase(Union[int, float, None], 1, 1),
+        UnionTestCase(Union[int, float, None], 1.2, 1.2),
+        UnionTestCase(Union[int, float, None], "1", 1),
+        UnionTestCase(Union[int, float, None], "1.2", 1.2),
+        UnionTestCase(Union[int, float, None], "a", None),
+        # None | int | float
+        UnionTestCase(Union[None, int, float], None, None),
+        UnionTestCase(Union[None, int, float], 1, 1),
+        UnionTestCase(Union[None, int, float], 1.2, 1.2),
+        UnionTestCase(Union[None, int, float], "1", None),
+        UnionTestCase(Union[None, int, float], "1.2", None),
+        UnionTestCase(Union[None, int, float], "a", None),
+        # int | None | float
+        UnionTestCase(Union[int, None, float], None, None),
+        UnionTestCase(Union[int, None, float], 1, 1),
+        UnionTestCase(Union[int, None, float], 1.2, 1.2),
+        UnionTestCase(Union[int, None, float], "1", 1),
+        UnionTestCase(Union[int, None, float], "1.2", None),
+        UnionTestCase(Union[int, None, float], "a", None),
+    ],
+)
+def test_union_deserialization(test_case):
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        x: test_case.type
+
+    instance = DataClass(x=test_case.loaded)
+    loaded = DataClass.from_dict({"x": test_case.dumped})
+    assert loaded == instance
+    assert same_types(loaded.x, instance.x)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        UnionTestCase(Union[int, str], 1, 1),
+        UnionTestCase(Union[int, str], "1", "1"),
         UnionTestCase(Union[int, str], "a", "a"),
         UnionTestCase(Union[Dict[int, int], List[int]], {1: 2}, {1: 2}),
         UnionTestCase(Union[Dict[int, int], List[int]], [1], [1]),
@@ -27,14 +122,15 @@ class UnionTestCase:
         UnionTestCase(Union[str, List[str]], "abc", "abc"),
     ],
 )
-def test_union(test_case):
+def test_union_serialization(test_case):
     @dataclass
     class DataClass(DataClassDictMixin):
         x: test_case.type
 
     instance = DataClass(x=test_case.loaded)
-    assert DataClass.from_dict({"x": test_case.dumped}) == instance
-    assert instance.to_dict() == {"x": test_case.dumped}
+    dumped = instance.to_dict()
+    assert dumped == {"x": test_case.dumped}
+    assert same_types(dumped["x"], test_case.dumped)
 
 
 def test_union_encoding():
@@ -43,12 +139,3 @@ def test_union_encoding():
             encoded = encode(value, Union[variants])
             assert value == encoded
             assert same_types(value, encoded)
-
-
-# TDDO: Convert this to a normal test
-# def test_str_bool_union_warning():
-#     with pytest.warns(UserWarning):
-#
-#         @dataclass
-#         class _(DataClassDictMixin):
-#             x: Union[str, bool]


### PR DESCRIPTION
Closes #42, #221, #252, #255 

This PR brings a new type of expression `TypeMatchEligibleExpression`. It conveys that the expression built for a `ValueSpec` is eligible for direct processing the value if the type matches, but doesn’t guarantee that it will always be processed that way. This information is used in `Union` deserialization algorithm to return the input value as is only when its type is in the list of expected types. The order of variant types still matters. The following value types will have `TypeMatchEligibleExpression`:
* `str`
* `bool`
* `int`
* `float`
* `NoneType`

If the input value type doesn't match any of the expected types, it will be processed as before or as written below.

This PR also changes the way how `str`, `bool` and `NoneType` values are processed on deserialization _outside_ on `Union`:
* Expected `str` value will processed as `str(value)`
* Expected `bool` value will be processed as `bool(value)`
* Expected `NoneType` value will always be `None` regardless of the input value

Some examples:

```python
@dataclass
class Foo(DataClassDictMixin):
    foo: str | int

Foo.from_dict({"foo": "1"})  # Foo(foo="1")
Foo.from_dict({"foo": 1})    # Foo(foo=1)
```

```python
@dataclass
class Foo(DataClassDictMixin):
    foo: int | str

Foo.from_dict({"foo": "1"})  # Foo(foo="1")
Foo.from_dict({"foo": 1})    # Foo(foo=1)
```

```python
@dataclass
class Foo(DataClassDictMixin):
    foo: str | date

Foo.from_dict({"foo": "2024-11-11"})  # Foo(foo="2024-11-11")
```

```python
@dataclass
class Foo(DataClassDictMixin):
    foo: date | str

Foo.from_dict({"foo": "2024-11-11"})  # Foo(foo=date(2024, 11, 11))
```

```python
@dataclass
class Foo(DataClassDictMixin):
    foo: int | float

Foo.from_dict({"foo": 1})      # Foo(foo=1)
Foo.from_dict({"foo": 1.0})    # Foo(foo=1.0)
Foo.from_dict({"foo": "1"})    # Foo(foo=1)
Foo.from_dict({"foo": "1.0"})  # Foo(foo=1.0)
```

```python
@dataclass
class Foo(DataClassDictMixin):
    foo: float | int

Foo.from_dict({"foo": 1})      # Foo(foo=1)
Foo.from_dict({"foo": 1.0})    # Foo(foo=1.0)
Foo.from_dict({"foo": "1"})    # Foo(foo=1)
Foo.from_dict({"foo": "1.0"})  # Foo(foo=1.0)
```

```python
@dataclass
class Foo(DataClassDictMixin):
    foo: bool | int

Foo.from_dict({"foo": 1})          # Foo(foo=1)
Foo.from_dict({"foo": True})       # Foo(foo=True)
Foo.from_dict({"foo": "1"})        # Foo(foo=True)
Foo.from_dict({"foo": [1, 2, 3]})  # Foo(foo=True)
Foo.from_dict({"foo": "1.2"})      # Foo(foo=True)
Foo.from_dict({"foo": [1, 2, 3]})  # Foo(foo=True)
```

```python
@dataclass
class Foo(DataClassDictMixin):
    foo: int | bool

Foo.from_dict({"foo": 1})          # Foo(foo=1)
Foo.from_dict({"foo": True})       # Foo(foo=True)
Foo.from_dict({"foo": "1"})        # Foo(foo=1)
Foo.from_dict({"foo": [1, 2, 3]})  # Foo(foo=True)
Foo.from_dict({"foo": "1.2"})      # Foo(foo=True)
Foo.from_dict({"foo": [1, 2, 3]})  # Foo(foo=True)
```

```python
@dataclass
class Foo(DataClassDictMixin):
    foo: type(None)

Foo.from_dict({"foo": 1})      # Foo(foo=None)
Foo.from_dict({"foo": "bar"})  # Foo(foo=None)
```

```python
@dataclass
class Foo(DataClassDictMixin):
    foo: tuple[type(None), type(None), type(None)]

Foo.from_dict({"foo": [1, 2, 3]})  # Foo(foo=(None, None, None))
```