### PR TITLE
Fix AttributeError when using generic SerializableType subclass

### DIFF
--- a/mashumaro/types.py
+++ b/mashumaro/types.py
@@ -29,6 +29,7 @@ class SerializableType:
         ] = Sentinel.MISSING,
         **kwargs: Any,
     ):
+        super().__init_subclass__(**kwargs)
         if use_annotations is not Sentinel.MISSING:
             cls.__use_annotations__ = use_annotations
 
@@ -61,6 +62,7 @@ class SerializationStrategy:
         ] = Sentinel.MISSING,
         **kwargs: Any,
     ):
+        super().__init_subclass__(**kwargs)
         if use_annotations is not Sentinel.MISSING:
             cls.__use_annotations__ = use_annotations
 


### PR DESCRIPTION
When using PEP 695 syntax to create a generic class, some private attributes are set up by the runtime in __init_subclass__(). Those attributes are needed when specializing the generic class.

SerializableType did not call super().__init_subclass__() and thus those attributes were missing, leading to an AttributeError.

Fixes https://github.com/Fatal1ty/mashumaro/issues/274