### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,9 @@ jobs:
     name: Code style tests
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -52,8 +53,9 @@ jobs:
       - test-code-style
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -70,7 +72,7 @@ jobs:
     - name: Run tests with coverage
       run: |
         source .venv/bin/activate
-        pytest --cov=mashumaro --cov=tests
+        pytest --numprocesses=auto --cov=mashumaro --cov=tests
     - name: Upload Coverage
       run: |
         source .venv/bin/activate
@@ -86,8 +88,9 @@ jobs:
       - test-code-style
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -105,7 +108,7 @@ jobs:
     - name: Run tests with coverage
       run: |
         .venv/Scripts/activate
-        pytest --cov=mashumaro --cov=tests
+        pytest --numprocesses=auto --cov=mashumaro --cov=tests
     - name: Upload Coverage
       run: |
         .venv/Scripts/activate

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,7 @@ jobs:
         source .venv/bin/activate
         pytest --numprocesses=auto --cov=mashumaro --cov=tests
     - name: Upload Coverage
+      if: matrix.python-version != '3.14'
       run: |
         source .venv/bin/activate
         coveralls --service=github
@@ -110,6 +111,7 @@ jobs:
         .venv/Scripts/activate
         pytest --numprocesses=auto --cov=mashumaro --cov=tests
     - name: Upload Coverage
+      if: matrix.python-version != '3.14'
       run: |
         .venv/Scripts/activate
         coveralls --service=github

--- a/mashumaro/core/const.py
+++ b/mashumaro/core/const.py
@@ -8,6 +8,7 @@ __all__ = [
     "PY_311_MIN",
     "PY_312_MIN",
     "PY_313_MIN",
+    "PY_314_MIN",
     "Sentinel",
 ]
 
@@ -17,6 +18,7 @@ PY_310 = sys.version_info.major == 3 and sys.version_info.minor == 10
 PY_311 = sys.version_info.major == 3 and sys.version_info.minor == 11
 PY_312 = sys.version_info.major == 3 and sys.version_info.minor == 12
 PY_313_MIN = sys.version_info.major == 3 and sys.version_info.minor >= 13
+PY_314_MIN = sys.version_info >= (3, 14)
 
 PY_312_MIN = PY_312 or PY_313_MIN
 PY_311_MIN = PY_311 or PY_312_MIN

--- a/mashumaro/core/meta/code/builder.py
+++ b/mashumaro/core/meta/code/builder.py
@@ -2,6 +2,7 @@ import enum
 import importlib
 import inspect
 import math
+import sys
 import types
 import typing
 import uuid
@@ -85,6 +86,11 @@ from mashumaro.exceptions import (  # noqa
 )
 from mashumaro.types import Alias, Discriminator
 
+if sys.version_info >= (3, 14):
+    from annotationlib import get_annotations
+else:
+    from typing_extensions import get_annotations  # type: ignore[attr-defined]
+
 __PRE_SERIALIZE__ = "__pre_serialize__"
 __PRE_DESERIALIZE__ = "__pre_deserialize__"
 __POST_SERIALIZE__ = "__post_serialize__"
@@ -167,7 +173,7 @@ class CodeBuilder:
 
     @property
     def annotations(self) -> dict[str, typing.Any]:
-        return self.namespace.get("__annotations__", {})
+        return get_annotations(self.cls, eval_str=True)
 
     @property
     def is_nailed(self) -> bool:

--- a/mashumaro/core/meta/code/builder.py
+++ b/mashumaro/core/meta/code/builder.py
@@ -343,7 +343,7 @@ class CodeBuilder:
         globalns = get_forward_ref_referencing_globals(
             typ, owner, self.globals
         )
-        return evaluate_forward_ref(typ, globalns, self.__dict__)
+        return evaluate_forward_ref(typ, globalns, self.__dict__, owner=owner)
 
     def get_declared_hook(self, method_name: str) -> typing.Any:
         cls = get_class_that_defines_method(method_name, self.cls)

--- a/mashumaro/core/meta/helpers.py
+++ b/mashumaro/core/meta/helpers.py
@@ -290,7 +290,7 @@ def type_name(
 def is_special_typing_primitive(typ: Any) -> bool:
     try:
         issubclass(typ, object)
-        return False
+        return PY_314_MIN and issubclass(typ, typing.Union)  # type: ignore[arg-type]
     except TypeError:
         return True
 

--- a/mashumaro/core/meta/helpers.py
+++ b/mashumaro/core/meta/helpers.py
@@ -35,6 +35,7 @@ from mashumaro.core.const import (
     PY_311_MIN,
     PY_312_MIN,
     PY_313_MIN,
+    PY_314_MIN,
 )
 from mashumaro.dialect import Dialect
 
@@ -760,8 +761,17 @@ def str_to_forward_ref(
 
 
 def evaluate_forward_ref(
-    typ: ForwardRef, globalns: dict[str, Any], localns: dict[str, Any]
+    typ: ForwardRef,
+    globalns: dict[str, Any],
+    localns: dict[str, Any],
+    *,
+    owner: Optional[type] = None,
 ) -> Optional[Type]:
+    if PY_314_MIN:
+        if owner is None or typ is owner:
+            return typing_extensions.evaluate_forward_ref(typ, globals=globalns)  # type: ignore[attr-defined]
+        else:
+            return typing_extensions.evaluate_forward_ref(typ, owner=owner)  # type: ignore[attr-defined]
     if PY_313_MIN:
         return typ._evaluate(
             globalns, localns, type_params=(), recursive_guard=frozenset()

--- a/mashumaro/core/meta/types/pack.py
+++ b/mashumaro/core/meta/types/pack.py
@@ -17,7 +17,7 @@ from typing import Any, ForwardRef, Optional, Tuple, Union
 
 import typing_extensions
 
-from mashumaro.core.const import PY_311_MIN
+from mashumaro.core.const import PY_311_MIN, PY_314_MIN
 from mashumaro.core.meta.code.lines import CodeLines
 from mashumaro.core.meta.helpers import (
     get_args,
@@ -816,7 +816,11 @@ def pack_collection(spec: ValueSpec) -> Optional[Expression]:
                 return f"{spec.expression}.copy()"
         return f"{{{ke}: {ve} for key, value in {spec.expression}.items()}}"
 
-    if issubclass(spec.origin_type, typing.ByteString):  # type: ignore
+    if (
+        not PY_314_MIN
+        and issubclass(spec.origin_type, typing.ByteString)  # type: ignore[arg-type,attr-defined]
+        or spec.origin_type in {bytes, bytearray}  # type: ignore[arg-type,attr-defined]
+    ):
         spec.builder.ensure_object_imported(encodebytes)
         return f"encodebytes({spec.expression}).decode()"
     elif issubclass(spec.origin_type, str):

--- a/mashumaro/core/meta/types/pack.py
+++ b/mashumaro/core/meta/types/pack.py
@@ -3,6 +3,7 @@ import enum
 import ipaddress
 import os
 import re
+import sys
 import typing
 import uuid
 import zoneinfo
@@ -74,6 +75,11 @@ from mashumaro.types import (
     SerializableType,
     SerializationStrategy,
 )
+
+if sys.version_info >= (3, 14):
+    from annotationlib import get_annotations
+else:
+    from typing_extensions import get_annotations  # type: ignore[attr-defined]
 
 __all__ = ["PackerRegistry"]
 
@@ -674,7 +680,7 @@ def pack_named_tuple(spec: ValueSpec) -> Expression:
     ]
     annotations = {
         k: resolved.get(v, v)
-        for k, v in getattr(spec.origin_type, "__annotations__", {}).items()
+        for k, v in get_annotations(spec.origin_type, eval_str=True).items()
     }
     fields = getattr(spec.type, "_fields", ())
     packers = []
@@ -716,7 +722,7 @@ def pack_typed_dict(spec: ValueSpec) -> Expression:
     ]
     annotations = {
         k: resolved.get(v, v)
-        for k, v in spec.origin_type.__annotations__.items()
+        for k, v in get_annotations(spec.origin_type, eval_str=True).items()
     }
     all_keys = list(annotations.keys())
     required_keys = getattr(spec.type, "__required_keys__", all_keys)

--- a/mashumaro/core/meta/types/unpack.py
+++ b/mashumaro/core/meta/types/unpack.py
@@ -1240,13 +1240,12 @@ def unpack_collection(spec: ValueSpec) -> Optional[Expression]:
                 )
             )
 
-    if issubclass(spec.origin_type, typing.ByteString):  # type: ignore
-        if spec.origin_type is bytes:
-            spec.builder.ensure_object_imported(decodebytes)
-            return f"decodebytes({spec.expression}.encode())"
-        elif spec.origin_type is bytearray:
-            spec.builder.ensure_object_imported(decodebytes)
-            return f"bytearray(decodebytes({spec.expression}.encode()))"
+    if spec.origin_type is bytes:
+        spec.builder.ensure_object_imported(decodebytes)
+        return f"decodebytes({spec.expression}.encode())"
+    elif spec.origin_type is bytearray:
+        spec.builder.ensure_object_imported(decodebytes)
+        return f"bytearray(decodebytes({spec.expression}.encode()))"
     elif issubclass(spec.origin_type, str):
         return TypeMatchEligibleExpression(f"str({spec.expression})")
     elif ensure_generic_collection_subclass(spec, list):

--- a/mashumaro/core/meta/types/unpack.py
+++ b/mashumaro/core/meta/types/unpack.py
@@ -6,6 +6,7 @@ import ipaddress
 import os
 import pathlib
 import re
+import sys
 import types
 import typing
 import uuid
@@ -91,6 +92,11 @@ from mashumaro.types import (
     SerializableType,
     SerializationStrategy,
 )
+
+if sys.version_info >= (3, 14):
+    from annotationlib import get_annotations
+else:
+    from typing_extensions import get_annotations  # type: ignore[attr-defined]
 
 try:
     import ciso8601
@@ -1063,7 +1069,7 @@ def unpack_named_tuple(spec: ValueSpec) -> Expression:
     ]
     annotations = {
         k: resolved.get(v, v)
-        for k, v in getattr(spec.origin_type, "__annotations__", {}).items()
+        for k, v in get_annotations(spec.origin_type, eval_str=True).items()
     }
     fields = getattr(spec.type, "_fields", ())
     defaults = getattr(spec.type, "_field_defaults", {})
@@ -1151,7 +1157,7 @@ def unpack_typed_dict(spec: ValueSpec) -> Expression:
     ]
     annotations = {
         k: resolved.get(v, v)
-        for k, v in spec.origin_type.__annotations__.items()
+        for k, v in get_annotations(spec.origin_type, eval_str=True).items()
     }
     all_keys = list(annotations.keys())
     required_keys = getattr(spec.type, "__required_keys__", all_keys)

--- a/mashumaro/jsonschema/schema.py
+++ b/mashumaro/jsonschema/schema.py
@@ -2,6 +2,7 @@ import collections.abc
 import datetime
 import ipaddress
 import os
+import sys
 import warnings
 from base64 import encodebytes
 from collections import ChainMap, Counter, deque
@@ -93,6 +94,11 @@ try:
     )
 except ImportError:  # pragma: no cover
     from mashumaro.mixins.json import DataClassJSONMixin  # type: ignore
+
+if sys.version_info >= (3, 14):
+    from annotationlib import get_annotations
+else:
+    from typing_extensions import get_annotations  # type: ignore[attr-defined]
 
 
 UTC_OFFSET_PATTERN = r"^UTC([+-][0-2][0-9]:[0-5][0-9])?$"
@@ -639,8 +645,8 @@ def on_named_tuple(instance: Instance, ctx: Context) -> JSONSchema:
     )[instance.origin_type]
     annotations = {
         k: resolved.get(v, v)
-        for k, v in getattr(
-            instance.origin_type, "__annotations__", {}
+        for k, v in get_annotations(
+            instance.origin_type, eval_str=True
         ).items()
     }
     fields = getattr(instance.type, "_fields", ())
@@ -685,7 +691,9 @@ def on_typed_dict(instance: Instance, ctx: Context) -> JSONObjectSchema:
     )[instance.origin_type]
     annotations = {
         k: resolved.get(v, v)
-        for k, v in instance.origin_type.__annotations__.items()
+        for k, v in get_annotations(
+            instance.origin_type, eval_str=True
+        ).items()
     }
     all_keys = list(annotations.keys())
     required_keys = getattr(instance.type, "__required_keys__", all_keys)

--- a/mashumaro/jsonschema/schema.py
+++ b/mashumaro/jsonschema/schema.py
@@ -153,6 +153,7 @@ class Instance:
                 new_type,
                 get_forward_ref_referencing_globals(new_type, self.type),
                 self.__dict__,
+                owner=self.origin_type,
             )
         new_instance = replace(self, **changes)
         if is_dataclass(self.origin_type):
@@ -471,6 +472,7 @@ def on_special_typing_primitive(
             instance.type,
             get_forward_ref_referencing_globals(instance.type),
             None,
+            owner=instance.origin_type,
         )
         if evaluated is not None:
             return get_schema(instance.derive(type=evaluated), ctx)

--- a/mashumaro/jsonschema/schema.py
+++ b/mashumaro/jsonschema/schema.py
@@ -1,3 +1,4 @@
+import collections.abc
 import datetime
 import ipaddress
 import os
@@ -5,7 +6,6 @@ import warnings
 from base64 import encodebytes
 from collections import ChainMap, Counter, deque
 from collections.abc import (
-    ByteString,
     Callable,
     Collection,
     Iterable,
@@ -25,7 +25,7 @@ from zoneinfo import ZoneInfo
 from typing_extensions import TypeAlias
 
 from mashumaro.config import BaseConfig
-from mashumaro.core.const import PY_311_MIN
+from mashumaro.core.const import PY_311_MIN, PY_314_MIN
 from mashumaro.core.meta.code.builder import CodeBuilder
 from mashumaro.core.meta.helpers import (
     evaluate_forward_ref,
@@ -751,7 +751,11 @@ def on_collection(instance: Instance, ctx: Context) -> Optional[JSONSchema]:
 
     args = get_args(instance.type)
 
-    if issubclass(instance.origin_type, ByteString):  # type: ignore[arg-type]
+    if (
+        not PY_314_MIN
+        and issubclass(instance.origin_type, collections.abc.ByteString)  # type: ignore[arg-type,attr-defined]
+        or instance.origin_type in (bytes, bytearray)
+    ):
         return JSONSchema(
             type=JSONSchemaInstanceType.STRING,
             format=JSONSchemaInstanceFormatExtension.BASE64,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 # extra
-msgpack>=0.5.6
+msgpack>=0.5.6;sys_platform != 'win32' or (sys_platform == 'win32' and python_version<'3.14')
 pyyaml>=3.13
 tomli-w>=1.0
 tomli>=1.1.0;python_version<'3.11'
-orjson>=3.10.10
+orjson>=3.10.10;python_version<'3.14'
 
 # tests
 mypy>=0.812
@@ -12,13 +12,13 @@ pytest>=6.2.1
 pytest-mock>=3.5.1
 pytest-cov>=2.10.1
 pytest-xdist>=3.5.0
-coveralls>=3.0.0
+coveralls>=3.0.0;python_version<'3.14'
 black==24.3.0
 ruff>=0.0.285
 codespell>=2.2.2
 
 # third party features
-ciso8601>=2.1.3
+ciso8601>=2.1.3;sys_platform != 'win32' or (sys_platform == 'win32' and python_version<'3.14')
 pendulum>=2.1.2;python_version<'3.13'
 
 # benchmark
@@ -26,7 +26,7 @@ pyperf>=2.6.1
 termtables>=0.2.3
 pytablewriter[html]>=0.58.0
 cattrs==24.1.2
-pydantic==2.9.2
+pydantic==2.9.2;python_version<'3.14'  # see https://github.com/pydantic/pydantic-core/pull/1714
 dacite==1.7.0  # see https://github.com/konradhalas/dacite/issues/236#issuecomment-1613987368
 marshmallow>=3.19.0
 dataclasses-json==0.6.7

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
     package_data={"mashumaro": ["py.typed", "mixins/orjson.pyi"]},
     python_requires=">=3.9",
     install_requires=[
-        "typing_extensions>=4.1.0",
+        "typing_extensions>=4.13.0;python_version<'3.14'",
+        "typing_extensions>=4.14.0rc1;python_version>='3.14'",
     ],
     extras_require={
         "orjson": ["orjson"],

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Development Status :: 5 - Production/Stable",
     ],
     license="Apache License, Version 2.0",

--- a/tests/test_jsonschema/test_jsonschema_generation.py
+++ b/tests/test_jsonschema/test_jsonschema_generation.py
@@ -14,10 +14,10 @@ from pathlib import (
     PureWindowsPath,
     WindowsPath,
 )
+import sys
 from typing import (
     AbstractSet,
     Any,
-    ByteString,
     ChainMap,
     Counter,
     DefaultDict,
@@ -41,6 +41,7 @@ import pytest
 from typing_extensions import Annotated, Literal, TypeVarTuple, Unpack
 
 from mashumaro.config import BaseConfig
+from mashumaro.core.const import PY_314_MIN
 from mashumaro.core.meta.helpers import type_name
 from mashumaro.helper import pass_through
 from mashumaro.jsonschema.annotations import (
@@ -113,6 +114,13 @@ from tests.test_pep_655 import (
     TypedDictCorrectNotRequired,
     TypedDictCorrectRequired,
 )
+
+if sys.version_info < (3, 14):
+    from collections.abc import ByteString as ColByteString
+    from typing import ByteString as TpByteString
+else:
+    ColByteString = None
+    TpByteString = None
 
 Ts = TypeVarTuple("Ts")
 
@@ -347,12 +355,32 @@ def test_jsonschema_for_fraction():
     )
 
 
-def test_jsonschema_for_bytestring():
-    for instance_type in (ByteString, bytes, bytearray):
-        assert build_json_schema(instance_type) == JSONSchema(
-            type=JSONSchemaInstanceType.STRING,
-            format=JSONSchemaInstanceFormatExtension.BASE64,
-        )
+@pytest.mark.parametrize(
+    ["instance_type"],
+    (
+        pytest.param(bytes),
+        pytest.param(bytearray),
+        pytest.param(
+            ColByteString,
+            id="ByteString",
+            marks=pytest.mark.skipif(
+                PY_314_MIN, reason="ByteString was removed in 3.14"
+            ),
+        ),
+        pytest.param(
+            TpByteString,
+            id="ByteString",
+            marks=pytest.mark.skipif(
+                PY_314_MIN, reason="ByteString was removed in 3.14"
+            ),
+        ),
+    ),
+)
+def test_jsonschema_for_bytestring(instance_type):
+    assert build_json_schema(instance_type) == JSONSchema(
+        type=JSONSchemaInstanceType.STRING,
+        format=JSONSchemaInstanceFormatExtension.BASE64,
+    )
 
 
 def test_jsonschema_for_str():


### PR DESCRIPTION
Relevant changes for Python 3.14
- `typing.ByteString` and `collections.abc.ByteString` were removed
- Annotation handling changed with [PEP 649](https://peps.python.org/pep-0649/). It's now recommended to use `annotationlib.get_annotations` / `typing_extensions.get_annotations` for it.
- A new function was added to help with forward references: `typing.evaluate_forward_ref`. It's also available from `typing_extensions`.

Most tests pass with 3.14.0b2 locally. However, there are quite a few test dependencies which aren't compatible / haven't released Win wheels yet. Will need for those before moving forward here. _Luckily there is still some time before `3.14.0` in October._