### PR TITLE
field_options: support for user extra args

### DIFF
--- a/mashumaro/helper.py
+++ b/mashumaro/helper.py
@@ -36,12 +36,14 @@ def field_options(
     ] = None,
     serialization_strategy: Optional[SerializationStrategy] = None,
     alias: Optional[str] = None,
+    **kwargs: Any,
 ) -> dict[str, Any]:
     return {
         "serialize": serialize,
         "deserialize": deserialize,
         "serialization_strategy": serialization_strategy,
         "alias": alias,
+        **kwargs,
     }
 
 


### PR DESCRIPTION
Hi.

There are situations when it is necessary to have support for additional keys in the metadata of a dataclass. This simple PR adds support of extra args in `field_options` helper function.