### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+name: Release
+
+on:
+  release:
+    types:
+      - published
+
+env:
+  DEFAULT_PYTHON: "3.13"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build release assets
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    steps:
+      - name: Check out code from Github
+        uses: actions/checkout@v5
+      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+        id: python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+      - name: Install requirements
+        run: |
+          python -m pip install build
+      - name: Build distributions
+        run: |
+          python -m build
+      - name: Upload release assets
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: release-assets
+          path: dist/
+
+  release-pypi:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    needs: ["build"]
+    environment:
+      name: PyPI
+      url: https://pypi.org/project/mashumaro/
+    permissions:
+      id-token: write
+    steps:
+      - name: Download release assets
+        uses: actions/download-artifact@v5
+        with:
+          name: release-assets
+          path: dist/
+      - name: Upload to PyPI
+        if: github.event_name == 'release'
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  release-github:
+    name: Upload assets to Github release
+    runs-on: ubuntu-latest
+    needs: ["build"]
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Download release assets
+        uses: actions/download-artifact@v5
+        with:
+          name: release-assets
+          path: dist/
+      - name: Sign the dists with Sigstore and upload assets to Github release
+        if: github.event_name == 'release'
+        uses: sigstore/gh-action-sigstore-python@v3.0.1
+        with:
+          inputs: |
+            ./dist/*.tar.gz
+            ./dist/*.whl


### PR DESCRIPTION
@Fatal1ty Not sure if you're interested. For pylint we use a release workflow which is automatically triggers on a published release. https://github.com/pylint-dev/pylint/blob/main/.github/workflows/release.yml

> [!IMPORTANT]
> You'll need to
> 1. Create an environment named `PyPI` (Github: Settings -> Environment)
> 2. Configure Trusted publishing on PyPI.
> https://docs.pypi.org/trusted-publishers/adding-a-publisher/