### PR TITLE
Remove references to `ByteString` deprecated in Python 3.14

### DIFF
--- a/mashumaro/core/meta/types/pack.py
+++ b/mashumaro/core/meta/types/pack.py
@@ -828,7 +828,7 @@ def pack_collection(spec: ValueSpec) -> Optional[Expression]:
                 return f"{spec.expression}.copy()"
         return f"{{{ke}: {ve} for key, value in {spec.expression}.items()}}"
 
-    if issubclass(spec.origin_type, typing.ByteString):  # type: ignore
+    if issubclass(spec.origin_type, bytes | bytearray | memoryview):  # type: ignore
         spec.builder.ensure_object_imported(encodebytes)
         return f"encodebytes({spec.expression}).decode()"
     elif issubclass(spec.origin_type, str):

--- a/mashumaro/core/meta/types/unpack.py
+++ b/mashumaro/core/meta/types/unpack.py
@@ -1253,7 +1253,7 @@ def unpack_collection(spec: ValueSpec) -> Optional[Expression]:
                 )
             )
 
-    if issubclass(spec.origin_type, typing.ByteString):  # type: ignore
+    if issubclass(spec.origin_type, bytes | bytearray | memoryview):  # type: ignore
         if spec.origin_type is bytes:
             spec.builder.ensure_object_imported(decodebytes)
             return f"decodebytes({spec.expression}.encode())"

--- a/mashumaro/jsonschema/schema.py
+++ b/mashumaro/jsonschema/schema.py
@@ -6,7 +6,6 @@ import warnings
 from base64 import encodebytes
 from collections import ChainMap, Counter, deque
 from collections.abc import (  # type: ignore[attr-defined]
-    ByteString,
     Callable,
     Collection,
     Iterable,
@@ -765,7 +764,7 @@ def on_collection(instance: Instance, ctx: Context) -> Optional[JSONSchema]:
 
     args = get_args(instance.type)
 
-    if issubclass(instance.origin_type, ByteString):  # type: ignore[arg-type]
+    if issubclass(instance.origin_type, bytes | bytearray | memoryview):  # type: ignore[arg-type]
         return JSONSchema(
             type=JSONSchemaInstanceType.STRING,
             format=JSONSchemaInstanceFormatExtension.BASE64,

--- a/tests/test_jsonschema/test_jsonschema_generation.py
+++ b/tests/test_jsonschema/test_jsonschema_generation.py
@@ -17,7 +17,6 @@ from pathlib import (
 from typing import (
     AbstractSet,
     Any,
-    ByteString,
     ChainMap,
     Counter,
     DefaultDict,
@@ -375,7 +374,7 @@ def test_jsonschema_for_fraction():
 
 
 def test_jsonschema_for_bytestring():
-    for instance_type in (ByteString, bytes, bytearray):
+    for instance_type in (memoryview, bytes, bytearray):
         assert build_json_schema(instance_type) == JSONSchema(
             type=JSONSchemaInstanceType.STRING,
             format=JSONSchemaInstanceFormatExtension.BASE64,


### PR DESCRIPTION
Python 3.14 throws the following error:
```python
AttributeError: module 'typing' has no attribute 'ByteString'
```

The deprectation includes:
* `typing.ByteString`
* `collection.abc.ByteString`

This PR replaces these references with the contents of the old `ByteString` type alias: `bytes | bytearray | memoryview`.