### PR TITLE
Fix cross-module generics using forward refs

### DIFF
--- a/mashumaro/core/meta/code/builder.py
+++ b/mashumaro/core/meta/code/builder.py
@@ -555,6 +555,30 @@ class CodeBuilder:
             format_name=self.format_name,
             decoder=self.decoder,
         )
+        try:
+            self._add_unpack_method_eager(method_name)
+        except UnresolvedTypeReferenceError:
+            config = self.get_config()
+            if (
+                not self.allow_postponed_evaluation
+                or not config.allow_postponed_evaluation
+            ):
+                raise
+            self.reset()
+            self._add_unpack_method_with_lazy_body(method_name)
+        self.compile()
+
+    def _add_unpack_method_with_lazy_body(self, method_name: str) -> None:
+
+        if self.dialect is None and self.is_nailed:
+            self.add_line("@classmethod")
+        self._add_unpack_method_definition(method_name)
+        with self.indent():
+            self._add_unpack_method_lines_lazy(method_name)
+        cache_name = f"__dialect_{self.format_name}_unpacker_cache__"
+        self._add_setattr_method(method_name, cache_name)
+
+    def _add_unpack_method_eager(self, method_name: str) -> None:
         if self.decoder is not None:
             self.add_type_modules(self.decoder)
         dialects_feature = self.is_code_generation_option_enabled(
@@ -577,7 +601,6 @@ class CodeBuilder:
             else:
                 self._add_unpack_method_lines(method_name)
         self._add_setattr_method(method_name, cache_name)
-        self.compile()
 
     def _add_unpack_method_definition(self, method_name: str) -> None:
         kwargs = ""
@@ -1111,6 +1134,27 @@ class CodeBuilder:
             format_name=self.format_name,
             encoder=self.encoder,
         )
+        try:
+            self._add_pack_method_eager(method_name)
+        except UnresolvedTypeReferenceError:
+            config = self.get_config()
+            if (
+                not self.allow_postponed_evaluation
+                or not config.allow_postponed_evaluation
+            ):
+                raise
+            self.reset()
+            self._add_pack_method_with_lazy_body(method_name)
+        self.compile()
+
+    def _add_pack_method_with_lazy_body(self, method_name: str) -> None:
+        self._add_pack_method_definition(method_name)
+        with self.indent():
+            self._add_pack_method_lines_lazy(method_name)
+        cache_name = f"__dialect_{self.format_name}_packer_cache__"
+        self._add_setattr_method(method_name, cache_name)
+
+    def _add_pack_method_eager(self, method_name: str) -> None:
         if self.encoder is not None:
             self.add_type_modules(self.encoder)
         dialects_feature = self.is_code_generation_option_enabled(
@@ -1131,7 +1175,6 @@ class CodeBuilder:
             else:
                 self._add_pack_method_lines(method_name)
         self._add_setattr_method(method_name, cache_name)
-        self.compile()
 
     def _add_setattr_method(
         self, method_name: InternalMethodName, cache_name: str

--- a/mashumaro/core/meta/types/pack.py
+++ b/mashumaro/core/meta/types/pack.py
@@ -66,6 +66,7 @@ from mashumaro.core.meta.types.common import (
     random_hex,
 )
 from mashumaro.exceptions import (
+    UnresolvedTypeReferenceError,
     UnserializableDataError,
     UnserializableField,
     UnsupportedSerializationEngine,
@@ -549,7 +550,14 @@ def pack_special_typing_primitive(spec: ValueSpec) -> Optional[Expression]:
         elif is_type_var_tuple(spec.type):
             return PackerRegistry.get(spec.copy(type=tuple[Any, ...]))
         elif isinstance(spec.type, ForwardRef):
-            evaluated = evaluate_forward_ref(spec.type)
+            try:
+                evaluated = evaluate_forward_ref(
+                    spec.type, owner=spec.owner or spec.builder.cls
+                )
+            except NameError as e:
+                raise UnresolvedTypeReferenceError(
+                    spec.builder.cls, spec.type.__forward_arg__
+                ) from e
             if evaluated is not None:
                 return PackerRegistry.get(spec.copy(type=evaluated))
         elif is_type_alias_type(spec.type):

--- a/mashumaro/core/meta/types/unpack.py
+++ b/mashumaro/core/meta/types/unpack.py
@@ -83,6 +83,7 @@ from mashumaro.core.meta.types.common import (
 )
 from mashumaro.exceptions import (
     ThirdPartyModuleNotFoundError,
+    UnresolvedTypeReferenceError,
     UnserializableDataError,
     UnserializableField,
     UnsupportedDeserializationEngine,
@@ -874,7 +875,14 @@ def unpack_special_typing_primitive(spec: ValueSpec) -> Optional[Expression]:
         elif is_type_var_tuple(spec.type):
             return UnpackerRegistry.get(spec.copy(type=tuple[Any, ...]))
         elif isinstance(spec.type, ForwardRef):
-            evaluated = evaluate_forward_ref(spec.type)
+            try:
+                evaluated = evaluate_forward_ref(
+                    spec.type, owner=spec.owner or spec.builder.cls
+                )
+            except NameError as e:
+                raise UnresolvedTypeReferenceError(
+                    spec.builder.cls, spec.type.__forward_arg__
+                ) from e
             if evaluated is not None:
                 return UnpackerRegistry.get(spec.copy(type=evaluated))
         elif is_type_alias_type(spec.type):

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from typing import Any, Generic, List, Mapping, Optional, TypeVar
 
+import pytest
+
 from mashumaro import DataClassDictMixin
 from mashumaro.mixins.json import DataClassJSONMixin
 from tests.entities import MyGenericDataClass, SerializableTypeGenericList
@@ -237,3 +239,57 @@ def test_self_referenced_generic_no_max_recursion_error():
     assert Bar.from_dict({"x": 42, "y": {"x": 33, "y": None}}) == obj
     assert obj.to_json() == '{"x": 42, "y": {"x": 33, "y": null}}'
     assert Bar.from_json('{"x": 42, "y": {"x": 33, "y": null}}') == obj
+
+
+@pytest.mark.parametrize("lazy", [True, False])
+def test_cross_module_generics_with_forward_refs(tmp_path, lazy):
+    base_code = f"""\
+from dataclasses import dataclass
+from mashumaro import DataClassDictMixin
+from mashumaro.config import BaseConfig
+from mashumaro.types import Discriminator
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+@dataclass
+class MyBase(Generic[T], DataClassDictMixin):
+    field: T
+
+    class Config(BaseConfig):
+        lazy_compilation = {lazy}
+
+"""
+    sub_code = """\
+from __future__ import annotations
+from dataclasses import dataclass
+from _base_mod import MyBase, T
+
+
+
+@dataclass
+class SubType(MyBase["Other"]): ...
+
+@dataclass
+class Other:
+    inner: int
+"""
+    base_file = tmp_path / "_base_mod.py"
+    sub_file = tmp_path / "_sub_mod.py"
+    base_file.write_text(base_code)
+    sub_file.write_text(sub_code)
+
+    import sys
+
+    original_path = sys.path.copy()
+    sys.path.insert(0, str(tmp_path))
+    try:
+        import _sub_mod
+
+        result = _sub_mod.SubType.from_dict({"field": {"inner": 42}})
+        assert type(result).__name__ == "SubType"
+
+    finally:
+        sys.path[:] = original_path
+        sys.modules.pop("_base_mod", None)
+        sys.modules.pop("_sub_mod", None)


### PR DESCRIPTION
Previously, mashumaro had an issue resolving forward references in module B when the field was declared in module A - it would only try to evaluate the forwardref inside module A's context