### PR TITLE
Improve error messages when discriminator matches

### DIFF
--- a/mashumaro/core/meta/code/builder.py
+++ b/mashumaro/core/meta/code/builder.py
@@ -70,6 +70,7 @@ from mashumaro.dialect import Dialect
 from mashumaro.exceptions import (  # noqa
     BadDialect,
     BadHookSignature,
+    DiscriminatedUnionError,
     ExtraKeysError,
     InvalidFieldValue,
     MissingDiscriminatorError,
@@ -1283,10 +1284,11 @@ class FieldUnpackerCodeBlockBuilder:
     ) -> None:
         with self.lines.indent("try:"):
             self._set_value(field_name, unpacked_value, in_kwargs)
-        with self.lines.indent("except:"):
+        with self.lines.indent("except Exception as exc:"):
             self.lines.append(
                 "raise InvalidFieldValue("
                 f"'{field_name}',{field_type_name},value,cls)"
+                " from exc"
             )
 
     def _set_value(

--- a/mashumaro/core/meta/types/unpack.py
+++ b/mashumaro/core/meta/types/unpack.py
@@ -225,6 +225,7 @@ class UnionUnpackerBuilder(AbstractUnpackerBuilder):
             if do_try:
                 with lines.indent("try:"):
                     lines.extend(unpacker_block)
+                lines.append("except DiscriminatedUnionError: raise")
                 lines.append("except Exception: pass")
             else:
                 lines.extend(unpacker_block)
@@ -411,48 +412,62 @@ class DiscriminatedUnionUnpackerBuilder(AbstractUnpackerBuilder):
                     " from None"
                 )
             with lines.indent("try:"):
-                if spec.builder.is_nailed:
-                    lines.append(f"return {chosen_cls}.{variant_method_call}")
-                else:
-                    lines.append(
-                        f"return {spec.attrs_registry_name}"
-                        f"[{chosen_cls}].{variant_method_call}"
-                    )
-            with lines.indent("except (KeyError, AttributeError):"):
-                lines.append(f"variants_map = {variants_map}")
-                with lines.indent(f"for variant in {variants}:"):
-                    if discriminator.variant_tagger_fn is not None:
-                        self._add_register_variant_tags(
-                            lines, variant_tagger_expr
-                        )
-                    else:
-                        with lines.indent("try:"):
-                            self._add_register_variant_tags(
-                                lines, variant_tagger_expr
-                            )
-                        with lines.indent("except KeyError:"):
-                            lines.append("continue")
-                    self._add_build_variant_unpacker(
-                        spec, lines, variant_method_name, variant_method_call
-                    )
                 with lines.indent("try:"):
                     if spec.builder.is_nailed:
                         lines.append(
-                            "return variants_map[discriminator]"
-                            f".{variant_method_call}"
+                            f"return {chosen_cls}.{variant_method_call}"
                         )
                     else:
                         lines.append(
-                            f"return {spec.attrs_registry_name}["
-                            "variants_map[discriminator]]"
-                            f".{variant_method_call}"
+                            f"return {spec.attrs_registry_name}"
+                            f"[{chosen_cls}].{variant_method_call}"
                         )
-                with lines.indent("except KeyError:"):
-                    lines.append(
-                        "raise SuitableVariantNotFoundError("
-                        f"{variants_type_expr}, '{discriminator.field}', "
-                        "discriminator) from None"
-                    )
+                with lines.indent("except (KeyError, AttributeError):"):
+                    lines.append(f"variants_map = {variants_map}")
+                    with lines.indent(f"for variant in {variants}:"):
+                        if discriminator.variant_tagger_fn is not None:
+                            self._add_register_variant_tags(
+                                lines, variant_tagger_expr
+                            )
+                        else:
+                            with lines.indent("try:"):
+                                self._add_register_variant_tags(
+                                    lines, variant_tagger_expr
+                                )
+                            with lines.indent("except KeyError:"):
+                                lines.append("continue")
+                        self._add_build_variant_unpacker(
+                            spec,
+                            lines,
+                            variant_method_name,
+                            variant_method_call,
+                        )
+                    with lines.indent("try:"):
+                        if spec.builder.is_nailed:
+                            lines.append(
+                                "return variants_map[discriminator]"
+                                f".{variant_method_call}"
+                            )
+                        else:
+                            lines.append(
+                                f"return {spec.attrs_registry_name}["
+                                "variants_map[discriminator]]"
+                                f".{variant_method_call}"
+                            )
+                    with lines.indent("except KeyError:"):
+                        lines.append(
+                            "raise SuitableVariantNotFoundError("
+                            f"{variants_type_expr}, '{discriminator.field}', "
+                            "discriminator) from None"
+                        )
+            with lines.indent("except (KeyError, AttributeError):"):
+                lines.append("raise")
+            with lines.indent(
+                "except (InvalidFieldValue, DiscriminatedUnionError, MissingField, ExtraKeysError, UnresolvedTypeReferenceError) as exc:"
+            ):
+                lines.append(
+                    f"raise DiscriminatedUnionError(discriminator) from exc"
+                )
         else:
             with lines.indent(f"for variant in {variants}:"):
                 with lines.indent("try:"):

--- a/mashumaro/exceptions.py
+++ b/mashumaro/exceptions.py
@@ -142,6 +142,16 @@ class InvalidFieldValue(ValueError):
         return s
 
 
+class DiscriminatedUnionError(Exception):
+    """A discriminator matched a variant but deserialization failed."""
+
+    def __init__(self, matched_variant: str):
+        self.matched_variant = matched_variant
+
+    def __str__(self) -> str:
+        return f"Deserialization failed for matched variant {self.matched_variant}"
+
+
 class MissingDiscriminatorError(LookupError):
     def __init__(self, field_name: str):
         self.field_name = field_name

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -5,8 +5,10 @@ import pytest
 
 from mashumaro import DataClassDictMixin
 from mashumaro.codecs import BasicDecoder
+from mashumaro.config import BaseConfig
 from mashumaro.core.meta.helpers import type_name
 from mashumaro.exceptions import (
+    DiscriminatedUnionError,
     ExtraKeysError,
     InvalidFieldValue,
     MissingDiscriminatorError,
@@ -18,6 +20,7 @@ from mashumaro.exceptions import (
     UnsupportedDeserializationEngine,
     UnsupportedSerializationEngine,
 )
+from mashumaro.types import Discriminator
 
 
 def test_missing_field_simple_field_type_name():
@@ -204,3 +207,79 @@ def test_extra_keys_error():
     with pytest.raises(ExtraKeysError) as exc_info:
         MyClass.from_dict({"x": "x", "y": "y"})
     assert str(exc_info.value).endswith(".MyClass: y")
+
+
+def test_deserialize_union_provides_helpful_info():
+
+    @dataclass
+    class MyClass(DataClassDictMixin):
+        class Config(BaseConfig):
+            discriminator = Discriminator(
+                field="typename",
+                include_subtypes=True,
+            )
+            forbid_extra_keys = True
+
+        typename: str = "MyClass"
+
+    @dataclass(kw_only=True)
+    class OtherClass(MyClass):
+        inner: int | float
+        typename: str = "OtherClass"
+
+    @dataclass
+    class RandomClass(DataClassDictMixin):
+        z: int
+
+    @dataclass
+    class ParentClass(DataClassDictMixin):
+        x: Union[int, MyClass, RandomClass]
+
+    with pytest.raises(InvalidFieldValue) as exc_info:
+        ParentClass.from_dict(
+            {"x": {"inner": "not an int", "typename": "OtherClass"}}
+        )
+
+    exc = exc_info.value
+    assert exc.field_name == "x"
+    assert exc.holder_class is ParentClass
+
+    cause = exc.__cause__
+    assert isinstance(cause, DiscriminatedUnionError)
+    assert cause.matched_variant == "OtherClass"
+    cause = cause.__cause__
+    assert isinstance(cause, InvalidFieldValue)
+    assert cause.field_name == "inner"
+    assert cause.holder_class is OtherClass
+    assert cause.field_value == "not an int"
+
+    # Now give it a missing field
+    with pytest.raises(InvalidFieldValue) as exc_info:
+        ParentClass.from_dict({"x": {"typename": "OtherClass"}})
+
+    exc = exc_info.value
+    assert exc.field_name == "x"
+    assert exc.holder_class is ParentClass
+    cause = exc.__cause__
+    assert isinstance(cause, DiscriminatedUnionError)
+    assert cause.matched_variant == "OtherClass"
+    cause = cause.__cause__
+    assert isinstance(cause, MissingField)
+    assert cause.field_name == "inner"
+    assert cause.holder_class is OtherClass
+
+    # Now give it a too many fields
+    with pytest.raises(InvalidFieldValue) as exc_info:
+        ParentClass.from_dict(
+            {"x": {"inner": 5, "bad": 6, "typename": "OtherClass"}}
+        )
+
+    exc = exc_info.value
+    assert exc.field_name == "x"
+    assert exc.holder_class is ParentClass
+    cause = exc.__cause__
+    assert isinstance(cause, DiscriminatedUnionError)
+    assert cause.matched_variant == "OtherClass"
+    cause = cause.__cause__
+    assert isinstance(cause, ExtraKeysError)
+    assert cause.extra_keys == {"bad"}


### PR DESCRIPTION
In using the library, I've often found it difficult to diagnose parser errors for union-fields.  I realized that mashumaro evaluates union-field types in a way that treats exceptions when parsing a specific type in the union as tolerable, swallowing it and moving onto the next type to parse until it finds a match or runs out of types to attempt to parse the data as

This PR improves error messages in the specific case where a discriminator for one of the union-types has a positive match but then fails parsing.   

Unfortunately doesnt make _every_ case easier to debug, but hopefully should help in at least some.