### PR TITLE
Add ability to use JSONSchema inside Annotated

### DIFF
--- a/README.md
+++ b/README.md
@@ -3073,6 +3073,78 @@ print(
 ```
 </details>
 
+For more complex field-level schema customization, `Annotated` can also be
+used with a `JSONSchema` instance. In that case, explicitly set schema
+attributes are applied on top of the automatically generated schema. This is
+especially useful for content-related keywords such as `contentEncoding`,
+`contentMediaType`, and `contentSchema`:
+
+```python
+from dataclasses import dataclass
+from typing import Annotated
+
+from mashumaro.jsonschema import build_json_schema
+from mashumaro.jsonschema.models import JSONSchema, JSONSchemaInstanceType
+
+
+@dataclass
+class Upload:
+    file: Annotated[
+        bytes,
+        JSONSchema(
+            contentEncoding="base64",
+            contentMediaType="application/pdf",
+        ),
+    ]
+    metadata: Annotated[
+        str,
+        JSONSchema(
+            contentMediaType="application/json",
+            contentSchema=JSONSchema(
+                type=JSONSchemaInstanceType.OBJECT,
+            ),
+        ),
+    ]
+
+
+print(build_json_schema(Upload).to_json())
+```
+
+<details>
+<summary>Click to show the result</summary>
+
+```json
+{
+    "type": "object",
+    "title": "Upload",
+    "properties": {
+        "file": {
+            "type": "string",
+            "format": "base64",
+            "contentEncoding": "base64",
+            "contentMediaType": "application/pdf"
+        },
+        "metadata": {
+            "type": "string",
+            "contentMediaType": "application/json",
+            "contentSchema": {
+                "type": "object"
+            }
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "file",
+        "metadata"
+    ]
+}
+```
+</details>
+
+This overlay mechanism is intended for regular schema keywords. Structural
+keywords such as `$schema`, `$ref`, and `$defs` are not applied from
+`Annotated[..., JSONSchema(...)]`.
+
 The [`$schema`](https://json-schema.org/draft/2020-12/json-schema-core.html#name-the-schema-keyword)
 keyword can be added by setting `with_dialect_uri` to True:
 
@@ -3466,8 +3538,13 @@ print(schema.to_json())
 
 ### Extending JSON Schema
 
-Using a `Config` class it is possible to override some parts of the schema.
-Currently, you can do the following:
+For field-level schema customization, prefer using
+`Annotated[..., JSONSchema(...)]` as shown above. It keeps schema overrides
+close to the field type and is the recommended way to add extra keywords such
+as `description`, `contentMediaType`, or `contentSchema`.
+
+Using a `Config` class is still useful when you need to override schema parts
+at the dataclass level. Currently, you can do the following:
 * override some field schemas using the "properties" key
 * change `additionalProperties` using the "additionalProperties" key
 

--- a/mashumaro/core/meta/code/builder.py
+++ b/mashumaro/core/meta/code/builder.py
@@ -10,10 +10,8 @@ from contextlib import contextmanager
 
 # noinspection PyProtectedMember
 from dataclasses import _FIELDS  # type: ignore
-from dataclasses import MISSING, Field, is_dataclass
+from dataclasses import KW_ONLY, MISSING, Field, is_dataclass
 from functools import lru_cache
-
-from dataclasses import KW_ONLY
 
 import typing_extensions
 

--- a/mashumaro/jsonschema/models.py
+++ b/mashumaro/jsonschema/models.py
@@ -154,6 +154,10 @@ class JSONSchema(DataClassJSONMixin):
     minProperties: int | None = None
     required: list[str] | None = None
     dependentRequired: dict[str, set[str]] | None = None
+    # A Vocabulary for the Contents of String-Encoded Data
+    contentEncoding: str | None = None
+    contentMediaType: str | None = None
+    contentSchema: "JSONSchema | None" = None
 
     class Config(BaseConfig):
         omit_none = True

--- a/mashumaro/jsonschema/schema.py
+++ b/mashumaro/jsonschema/schema.py
@@ -277,6 +277,8 @@ def get_schema(
             if with_dialect_uri:
                 schema.schema = ctx.dialect.uri
             break
+    if schema is not None:
+        apply_schema_annotations(instance, schema)
     for plugin in ctx.plugins:
         try:
             new_schema = plugin.get_schema(instance, ctx, schema)
@@ -296,6 +298,23 @@ def _get_schema_or_none(instance: Instance, ctx: Context) -> JSONSchema | None:
     schema = get_schema(instance, ctx)
     if isinstance(schema, EmptyJSONSchema):
         return None
+    return schema
+
+
+def apply_schema_annotations(
+    instance: Instance, schema: JSONSchema
+) -> JSONSchema:
+    for annotation in instance.annotations:
+        if isinstance(annotation, JSONSchema):
+            annotation_dict = replace(annotation).to_dict()
+            for key in annotation_dict.keys():
+                if key in ("$schema", "$ref", "$defs"):
+                    continue
+                if key in ("const", "default"):
+                    value = annotation_dict[key]
+                else:
+                    value = getattr(annotation, key)
+                setattr(schema, key, value)
     return schema
 
 

--- a/tests/test_jsonschema/test_jsonschema_generation.py
+++ b/tests/test_jsonschema/test_jsonschema_generation.py
@@ -1543,3 +1543,121 @@ def test_jsonschema_for_dataclass_with_slots():
         additionalProperties=False,
         required=["no_default"],
     )
+
+
+def test_jsonschema_annotation_overlay_for_content_keywords():
+    assert build_json_schema(
+        Annotated[
+            bytes,
+            JSONSchema(contentEncoding="base64", contentMediaType="image/png"),
+        ]
+    ) == JSONSchema(
+        type=JSONSchemaInstanceType.STRING,
+        format=JSONSchemaInstanceFormatExtension.BASE64,
+        contentEncoding="base64",
+        contentMediaType="image/png",
+    )
+
+
+def test_jsonschema_annotation_overlay_for_content_schema():
+    payload_schema = JSONObjectSchema(
+        properties={"value": JSONSchema(type=JSONSchemaInstanceType.INTEGER)},
+        additionalProperties=False,
+        required=["value"],
+    )
+
+    assert build_json_schema(
+        Annotated[
+            str,
+            JSONSchema(
+                contentMediaType="application/json",
+                contentSchema=payload_schema,
+            ),
+        ]
+    ) == JSONSchema(
+        type=JSONSchemaInstanceType.STRING,
+        contentMediaType="application/json",
+        contentSchema=payload_schema,
+    )
+
+
+def test_jsonschema_annotation_overlay_combines_with_constraints():
+    assert build_json_schema(
+        Annotated[
+            str,
+            MinLength(1),
+            JSONSchema(
+                contentMediaType="text/plain", description="Request body"
+            ),
+        ]
+    ) == JSONSchema(
+        type=JSONSchemaInstanceType.STRING,
+        minLength=1,
+        contentMediaType="text/plain",
+        description="Request body",
+    )
+
+
+def test_jsonschema_annotation_overlay_preserves_serialized_none_values():
+    assert build_json_schema(
+        Annotated[str, JSONSchema(const=None, default=None)]
+    ) == JSONSchema(
+        type=JSONSchemaInstanceType.STRING, const=None, default=None
+    )
+
+
+def test_jsonschema_annotation_overlay_for_dataclass_field():
+    @dataclass
+    class Upload:
+        file: Annotated[
+            bytes,
+            JSONSchema(
+                contentEncoding="base64", contentMediaType="application/pdf"
+            ),
+        ]
+
+    assert build_json_schema(Upload) == JSONObjectSchema(
+        title="Upload",
+        properties={
+            "file": JSONSchema(
+                type=JSONSchemaInstanceType.STRING,
+                format=JSONSchemaInstanceFormatExtension.BASE64,
+                contentEncoding="base64",
+                contentMediaType="application/pdf",
+            )
+        },
+        additionalProperties=False,
+        required=["file"],
+    )
+
+
+def test_jsonschema_annotation_overlay_last_wins():
+    assert build_json_schema(
+        Annotated[
+            str,
+            JSONSchema(description="First description"),
+            JSONSchema(description="Second description"),
+        ]
+    ) == JSONSchema(
+        type=JSONSchemaInstanceType.STRING, description="Second description"
+    )
+
+
+def test_jsonschema_annotation_overlay_ignores_structural_keywords():
+    assert build_json_schema(
+        Annotated[
+            str,
+            JSONSchema(
+                schema="https://json-schema.org/draft/2020-12/schema",
+                reference="#/$defs/UploadedFile",
+                definitions={
+                    "UploadedFile": JSONSchema(
+                        type=JSONSchemaInstanceType.STRING
+                    )
+                },
+                description="Plain string",
+            ),
+        ]
+    ) == JSONSchema(
+        type=JSONSchemaInstanceType.STRING, description="Plain string"
+    )


### PR DESCRIPTION
## Summary

This PR adds support for using `Annotated[..., JSONSchema(...)]` in JSON Schema generation.

When a `JSONSchema` instance is present in `typing.Annotated` metadata, its explicitly set attributes are applied on top of the automatically generated schema. This provides a convenient field-level API for adding schema keywords such as:

- `description`
- `contentEncoding`
- `contentMediaType`
- `contentSchema`
- and other regular JSON Schema keywords

## Motivation

Users may want to attach JSON Schema keywords directly to a field type, especially for content-related use cases such as multipart/form-data payloads.

Example:

```python
from typing import Annotated
from mashumaro.jsonschema.models import JSONSchema

file: Annotated[
    bytes,
    JSONSchema(
        contentEncoding="string",
        contentMediaType="application/octet-stream",
    ),
]