### PR TITLE
Fix serialization of unions with nested PEP 695 type aliases

### DIFF
--- a/mashumaro/core/meta/helpers.py
+++ b/mashumaro/core/meta/helpers.py
@@ -645,17 +645,57 @@ def substitute_type_params(typ: Type, substitutions: dict[Type, Type]) -> Type:
 
 
 def resolve_type_alias_type(typ: Type) -> Type:
+    seen = set()
+    steps = 0
     while True:
+        if is_hashable(typ):
+            if typ in seen:  # cyclic alias, e.g. "type A = B; type B = A"
+                break
+            seen.add(typ)
         if is_type_alias_type(typ):
             typ = typ.__value__
-        elif is_type_alias_type(get_type_origin(typ)):
+        elif not is_annotated(typ) and is_type_alias_type(
+            get_type_origin(typ)
+        ):
             origin = get_type_origin(typ)
             type_params = getattr(origin, "__type_params__", ())
             args = get_args(typ)
             param_map = dict(zip(type_params, args))
+            # subscription arity can only be checked for plain type vars:
+            # TypeVarTuple and ParamSpec allow a variable number of args
+            if all(is_type_var(p) for p in type_params):
+                if len(args) > len(type_params):
+                    raise TypeError(
+                        f"Too many arguments for {type_name(origin)}; "
+                        f"actual {len(args)}, expected {len(type_params)}"
+                    )
+                for type_param in type_params[len(args) :]:
+                    if not type_var_has_default(type_param):
+                        raise TypeError(
+                            f"Too few arguments for {type_name(origin)}; "
+                            f"actual {len(args)}, "
+                            f"expected {len(type_params)}"
+                        )
+                    default = get_type_var_default(type_param)
+                    param_map[type_param] = substitute_type_params(
+                        default, param_map
+                    )
             typ = substitute_type_params(origin.__value__, param_map)
         else:
             return typ
+        # the number of steps is bounded so that unresolvable recursive
+        # aliases with non-repeating values, e.g. "type G[T] = G[list[T]]",
+        # terminate
+        steps += 1
+        if steps > 64:
+            break
+    if is_type_alias_type(typ) or (
+        not is_annotated(typ) and is_type_alias_type(get_type_origin(typ))
+    ):
+        raise TypeError(
+            f"Cannot resolve recursive type alias {type_name(typ)}"
+        )
+    return typ
 
 
 def get_name_error_name(e: NameError) -> str:

--- a/mashumaro/core/meta/helpers.py
+++ b/mashumaro/core/meta/helpers.py
@@ -43,6 +43,7 @@ __all__ = [
     "is_dataclass_dict_mixin_subclass",
     "collect_type_params",
     "resolve_type_params",
+    "resolve_type_alias_type",
     "substitute_type_params",
     "get_generic_name",
     "get_name_error_name",
@@ -639,6 +640,20 @@ def substitute_type_params(typ: Type, substitutions: dict[Type, Type]) -> Type:
                 return typ[tuple(new_type_args)]
         if is_hashable(typ):
             return substitutions.get(typ, typ)
+        else:
+            return typ
+
+
+def resolve_type_alias_type(typ: Type) -> Type:
+    while True:
+        if is_type_alias_type(typ):
+            typ = typ.__value__
+        elif is_type_alias_type(get_type_origin(typ)):
+            origin = get_type_origin(typ)
+            type_params = getattr(origin, "__type_params__", ())
+            args = get_args(typ)
+            param_map = dict(zip(type_params, args))
+            typ = substitute_type_params(origin.__value__, param_map)
         else:
             return typ
 

--- a/mashumaro/core/meta/types/pack.py
+++ b/mashumaro/core/meta/types/pack.py
@@ -47,6 +47,7 @@ from mashumaro.core.meta.helpers import (
     is_union,
     is_unpack,
     not_none_type_arg,
+    resolve_type_alias_type,
     resolve_type_params,
     substitute_type_params,
     type_name,
@@ -325,6 +326,7 @@ def pack_union(
     packers: list[str] = []
     packer_arg_types: dict[str, list[type]] = {}
     for type_arg in args:
+        type_arg = resolve_type_alias_type(type_arg)
         packer = PackerRegistry.get(
             spec.copy(type=type_arg, expression="value", owner=spec.type)
         )
@@ -549,15 +551,12 @@ def pack_special_typing_primitive(spec: ValueSpec) -> Expression | None:
             evaluated = evaluate_forward_ref(spec.type)
             if evaluated is not None:
                 return PackerRegistry.get(spec.copy(type=evaluated))
-        elif is_type_alias_type(spec.type):
-            return PackerRegistry.get(spec.copy(type=spec.type.__value__))
-        elif is_type_alias_type(get_type_origin(spec.type)):
-            origin = get_type_origin(spec.type)
-            type_params = getattr(origin, "__type_params__", ())
-            args = get_args(spec.type)
-            param_map = dict(zip(type_params, args))
-            resolved = substitute_type_params(origin.__value__, param_map)
-            return PackerRegistry.get(spec.copy(type=resolved))
+        elif is_type_alias_type(spec.type) or is_type_alias_type(
+            get_type_origin(spec.type)
+        ):
+            return PackerRegistry.get(
+                spec.copy(type=resolve_type_alias_type(spec.type))
+            )
         elif is_readonly(spec.type):
             return PackerRegistry.get(spec.copy(type=get_args(spec.type)[0]))
         raise UnserializableDataError(

--- a/mashumaro/core/meta/types/unpack.py
+++ b/mashumaro/core/meta/types/unpack.py
@@ -60,6 +60,7 @@ from mashumaro.core.meta.helpers import (
     is_unpack,
     iter_all_subclasses,
     not_none_type_arg,
+    resolve_type_alias_type,
     resolve_type_params,
     substitute_type_params,
     type_name,
@@ -195,6 +196,7 @@ class UnionUnpackerBuilder(AbstractUnpackerBuilder):
         type_arg_unpackers = []
         type_match_statements = 0
         for type_arg in self.union_args:
+            type_arg = resolve_type_alias_type(type_arg)
             unpacker = UnpackerRegistry.get(
                 spec.copy(type=type_arg, expression="value", owner=spec.type)
             )
@@ -874,15 +876,12 @@ def unpack_special_typing_primitive(spec: ValueSpec) -> Expression | None:
             evaluated = evaluate_forward_ref(spec.type)
             if evaluated is not None:
                 return UnpackerRegistry.get(spec.copy(type=evaluated))
-        elif is_type_alias_type(spec.type):
-            return UnpackerRegistry.get(spec.copy(type=spec.type.__value__))
-        elif is_type_alias_type(get_type_origin(spec.type)):
-            origin = get_type_origin(spec.type)
-            type_params = getattr(origin, "__type_params__", ())
-            args = get_args(spec.type)
-            param_map = dict(zip(type_params, args))
-            resolved = substitute_type_params(origin.__value__, param_map)
-            return UnpackerRegistry.get(spec.copy(type=resolved))
+        elif is_type_alias_type(spec.type) or is_type_alias_type(
+            get_type_origin(spec.type)
+        ):
+            return UnpackerRegistry.get(
+                spec.copy(type=resolve_type_alias_type(spec.type))
+            )
         elif is_readonly(spec.type):
             return UnpackerRegistry.get(spec.copy(type=get_args(spec.type)[0]))
         raise UnserializableDataError(

--- a/tests/test_pep_695.py
+++ b/tests/test_pep_695.py
@@ -5,6 +5,7 @@ import pytest
 
 from mashumaro import DataClassDictMixin
 from mashumaro.codecs import BasicDecoder, BasicEncoder
+from mashumaro.config import TO_DICT_ADD_OMIT_NONE_FLAG, BaseConfig
 from mashumaro.exceptions import MissingField
 from tests.entities_pep_695 import (
     Boxed,
@@ -144,3 +145,73 @@ def test_recursive_generic_alias_with_serializable_type():
         DataClassWithRecursiveGenericAlias.from_dict({"x": ("hello", 7)})
         == obj2
     )
+
+
+def test_type_alias_type_nested_in_union():
+    # https://github.com/Fatal1ty/mashumaro/issues/330
+    type UniqueIdentifier = str
+    type UniqueIdentifierList = list[UniqueIdentifier]
+    type UniqueIdentifierOrList = UniqueIdentifier | UniqueIdentifierList
+
+    @dataclass
+    class MyClass(DataClassDictMixin):
+        x: UniqueIdentifierOrList | None = None
+
+    assert MyClass(x="a").to_dict() == {"x": "a"}
+    assert MyClass(x=["a", "b"]).to_dict() == {"x": ["a", "b"]}
+    assert MyClass().to_dict() == {"x": None}
+    assert MyClass.from_dict({"x": "a"}) == MyClass(x="a")
+    assert MyClass.from_dict({"x": ["a", "b"]}) == MyClass(x=["a", "b"])
+    assert MyClass.from_dict({"x": None}) == MyClass()
+
+
+@pytest.mark.parametrize("lazy", [False, True])
+def test_type_alias_type_nested_in_union_with_omit_none_flag(lazy):
+    type UniqueIdentifier = str
+    type UniqueIdentifierList = list[UniqueIdentifier]
+    type UniqueIdentifierOrList = UniqueIdentifier | UniqueIdentifierList
+
+    @dataclass
+    class MyClass(DataClassDictMixin):
+        x: UniqueIdentifierOrList | None = None
+
+        class Config(BaseConfig):
+            code_generation_options = [TO_DICT_ADD_OMIT_NONE_FLAG]
+            lazy_compilation = lazy
+
+    assert MyClass(x="a").to_dict(omit_none=True) == {"x": "a"}
+    assert MyClass(x=["a", "b"]).to_dict(omit_none=True) == {"x": ["a", "b"]}
+    assert MyClass().to_dict(omit_none=True) == {}
+    assert MyClass.from_dict({"x": ["a", "b"]}) == MyClass(x=["a", "b"])
+
+
+def test_type_alias_type_nested_in_union_with_codecs():
+    type UniqueIdentifier = str
+    type UniqueIdentifierList = list[UniqueIdentifier]
+    type UniqueIdentifierOrList = UniqueIdentifier | UniqueIdentifierList
+
+    decoder = BasicDecoder(UniqueIdentifierOrList)
+    encoder = BasicEncoder(UniqueIdentifierOrList)
+
+    assert decoder.decode("a") == "a"
+    assert decoder.decode(["a", "b"]) == ["a", "b"]
+    assert encoder.encode("a") == "a"
+    assert encoder.encode(["a", "b"]) == ["a", "b"]
+
+
+def test_parameterized_type_alias_type_in_union():
+    type Identity[T] = T
+    type ListOf[T] = list[T]
+
+    @dataclass
+    class MyClass(DataClassDictMixin):
+        x: date | ListOf[int]
+        y: int | Identity[str]
+
+    obj1 = MyClass(x=date(2024, 4, 15), y=42)
+    assert obj1.to_dict() == {"x": "2024-04-15", "y": 42}
+    assert MyClass.from_dict({"x": "2024-04-15", "y": 42}) == obj1
+
+    obj2 = MyClass(x=[1, 2, 3], y="a")
+    assert obj2.to_dict() == {"x": [1, 2, 3], "y": "a"}
+    assert MyClass.from_dict({"x": [1, 2, 3], "y": "a"}) == obj2

--- a/tests/test_pep_695.py
+++ b/tests/test_pep_695.py
@@ -1,11 +1,14 @@
 from dataclasses import dataclass
 from datetime import date
+from typing import Annotated, Callable, TypeAliasType
 
 import pytest
+from typing_extensions import TypeVar
 
 from mashumaro import DataClassDictMixin
 from mashumaro.codecs import BasicDecoder, BasicEncoder
 from mashumaro.config import TO_DICT_ADD_OMIT_NONE_FLAG, BaseConfig
+from mashumaro.core.meta.helpers import resolve_type_alias_type
 from mashumaro.exceptions import MissingField
 from tests.entities_pep_695 import (
     Boxed,
@@ -215,3 +218,86 @@ def test_parameterized_type_alias_type_in_union():
     obj2 = MyClass(x=[1, 2, 3], y="a")
     assert obj2.to_dict() == {"x": [1, 2, 3], "y": "a"}
     assert MyClass.from_dict({"x": [1, 2, 3], "y": "a"}) == obj2
+
+
+def test_resolve_cyclic_type_alias_type():
+    type A = B
+    type B = A
+
+    with pytest.raises(TypeError, match="Cannot resolve recursive"):
+        resolve_type_alias_type(A)
+
+    with pytest.raises(TypeError, match="Cannot resolve recursive"):
+
+        @dataclass
+        class MyClass(DataClassDictMixin):
+            x: A | int
+
+
+def test_resolve_cyclic_parameterized_type_alias_type():
+    type ListOf[T] = ListOf[T]
+
+    with pytest.raises(TypeError, match="Cannot resolve recursive"):
+        resolve_type_alias_type(ListOf[int])
+
+
+def test_resolve_growing_recursive_type_alias_type():
+    type G[T] = G[list[T]]
+
+    with pytest.raises(TypeError, match="Cannot resolve recursive"):
+        resolve_type_alias_type(G[int])
+
+
+def test_resolve_type_alias_type_with_wrong_number_of_type_args():
+    type Pair[K, V] = dict[K, V]
+
+    # subscription itself doesn't validate the number of args
+    with pytest.raises(TypeError, match="Too few arguments"):
+        resolve_type_alias_type(Pair[int])
+    with pytest.raises(TypeError, match="Too many arguments"):
+        resolve_type_alias_type(Pair[int, str, bytes])
+
+
+def test_resolve_type_alias_type_with_defaulted_type_params():
+    K = TypeVar("K")
+    V = TypeVar("V", default=str)
+    Pair = TypeAliasType("Pair", dict[K, V], type_params=(K, V))
+
+    assert resolve_type_alias_type(Pair[int]) == dict[int, str]
+    assert resolve_type_alias_type(Pair[int, bytes]) == dict[int, bytes]
+
+
+def test_type_alias_type_with_defaulted_type_param_in_union():
+    K = TypeVar("K")
+    V = TypeVar("V", default=str)
+    Pair = TypeAliasType("Pair", dict[K, V], type_params=(K, V))
+
+    @dataclass
+    class MyClass(DataClassDictMixin):
+        x: Pair[int] | None = None
+
+    assert MyClass(x={1: "a"}).to_dict() == {"x": {1: "a"}}
+    assert MyClass.from_dict({"x": {1: "a"}}) == MyClass(x={1: "a"})
+
+
+def test_annotated_type_alias_type_in_union():
+    type BareAlias = int
+
+    annotated = Annotated[BareAlias, "meta"]
+    assert resolve_type_alias_type(annotated) == annotated
+
+    @dataclass
+    class MyClass(DataClassDictMixin):
+        x: str | Annotated[BareAlias, "meta"]
+
+    # deserialization of annotated union members is a pre-existing
+    # limitation unrelated to type aliases, so only packing is checked here
+    assert MyClass(x="a").to_dict() == {"x": "a"}
+    assert MyClass(x=5).to_dict() == {"x": 5}
+
+
+def test_resolve_param_spec_type_alias_type_arity_not_checked():
+    type CB[**P] = Callable[P, int]
+
+    # ParamSpec subscription arity is flexible, resolution is best effort
+    resolve_type_alias_type(CB[int, str])


### PR DESCRIPTION
Fixes #330

When a union contains a PEP 695 `type` alias as one of its members, serializer generation crashed with `TypeError: issubclass() arg 1 must be a class`, because `pack_union` passed the raw `TypeAliasType` object to `issubclass(get_type_origin(type_arg), Collection)`. The deserialization path had the symmetric problem: `UnionUnpackerBuilder` generated type-match conditions from the alias's `__name__`, which raised `NameError` at decode time.

Changes:
- Added a `resolve_type_alias_type()` helper to `mashumaro/core/meta/helpers.py` that fully resolves `TypeAliasType` objects, including parameterized aliases (`type ListOf[T] = list[T]`) via `substitute_type_params`.
- Applied it to union members in `pack_union` and `UnionUnpackerBuilder._add_body`.
- Refactored the existing alias-unwrapping branches in `pack_special_typing_primitive` and `unpack_special_typing_primitive` to use the same helper (behavior unchanged).
- Added regression tests covering the issue's repro, the `TO_DICT_ADD_OMIT_NONE_FLAG` variant with eager and lazy compilation, codecs, and parameterized aliases as union members. All fail before the fix.