### PR TITLE
Fix data loss for dict with bool keys on JSON round-trip

### DIFF
--- a/mashumaro/core/helpers.py
+++ b/mashumaro/core/helpers.py
@@ -1,7 +1,8 @@
 import datetime
 import re
+from typing import Any
 
-__all__ = ["parse_timezone", "ConfigValue", "UTC_OFFSET_PATTERN"]
+__all__ = ["parse_timezone", "parse_bool", "ConfigValue", "UTC_OFFSET_PATTERN"]
 
 
 UTC_OFFSET_PATTERN = r"^UTC(([+-][0-2][0-9]):([0-5][0-9]))?$"
@@ -24,6 +25,20 @@ def parse_timezone(s: str) -> datetime.timezone:
         )
     else:
         return datetime.timezone.utc
+
+
+def parse_bool(value: Any) -> bool:
+    # When a bool is used as a mapping key, JSON serialization turns it
+    # into the string "true"/"false" (object keys must be strings), so the
+    # value coming back from the decoder is that string rather than a real
+    # bool. Plain bool(value) would treat both "true" and "false" as True,
+    # collapsing the keys, so the strings are mapped back explicitly here.
+    if isinstance(value, str):
+        if value == "true":
+            return True
+        if value == "false":
+            return False
+    return bool(value)
 
 
 class ConfigValue:

--- a/mashumaro/core/meta/types/unpack.py
+++ b/mashumaro/core/meta/types/unpack.py
@@ -31,7 +31,7 @@ import typing_extensions
 from typing_extensions import NotRequired
 
 from mashumaro.core.const import PY_311_MIN
-from mashumaro.core.helpers import parse_timezone
+from mashumaro.core.helpers import parse_bool, parse_timezone
 from mashumaro.core.meta.code.lines import CodeLines
 from mashumaro.core.meta.helpers import (
     get_args,
@@ -901,7 +901,8 @@ def unpack_number(spec: ValueSpec) -> Expression | None:
 @register
 def unpack_bool(spec: ValueSpec) -> Expression | None:
     if spec.origin_type is bool:
-        return TypeMatchEligibleExpression(f"bool({spec.expression})")
+        spec.builder.ensure_object_imported(parse_bool)
+        return TypeMatchEligibleExpression(f"parse_bool({spec.expression})")
 
 
 @register

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List
+from typing import Dict, List
 
 import pytest
 
@@ -84,6 +84,18 @@ def test_json_bytes():
 
     dumped = r'{"x": "MTIz\n"}'
     instance = DataClass(b"123")
+
+    assert instance.to_json() == dumped
+    assert DataClass.from_json(dumped) == instance
+
+
+def test_json_dict_with_bool_keys():
+    @dataclass
+    class DataClass(DataClassJSONMixin):
+        x: Dict[bool, str]
+
+    instance = DataClass(x={True: "a", False: "b"})
+    dumped = json.dumps({"x": {True: "a", False: "b"}})
 
     assert instance.to_json() == dumped
     assert DataClass.from_json(dumped) == instance


### PR DESCRIPTION
Fixes #333.

A `Dict[bool, ...]` field loses entries on a JSON round-trip: every key comes back as `True`, so the `False` entry is dropped.

JSON object keys have to be strings, so `to_json` writes bool keys as `"true"`/`"false"`. On the way back the unpacker rebuilt them with `bool(key)`, and `bool("false")` is `True`, so both keys collapsed onto `True` and one value overwrote the other. The dict path was unaffected because it keeps real bool keys.

I moved bool unpacking to a small `parse_bool` helper that maps the `"true"`/`"false"` strings back to their bool values and passes everything else through `bool()` as before, so real bool keys (dict path, and formats like YAML that keep native bool keys) still work unchanged.

Added a JSON round-trip test for `Dict[bool, str]`; it fails on master and passes here. Full suite, mypy, ruff and black are green.
