### PR TITLE
fix: resolve TypeAliasType before issubclass in pack_union (fixes #330)

### DIFF
--- a/mashumaro/core/meta/types/pack.py
+++ b/mashumaro/core/meta/types/pack.py
@@ -292,6 +292,12 @@ def pack_any(spec: ValueSpec) -> Expression | None:
         return spec.expression
 
 
+def _resolve_type_alias_type(t: type) -> type:
+    while is_type_alias_type(t):
+        t = t.__value__  # type: ignore[attr-defined]
+    return t
+
+
 def pack_union(
     spec: ValueSpec, args: tuple[type, ...], prefix: str = "union"
 ) -> Expression:
@@ -330,7 +336,7 @@ def pack_union(
         )
         if packer not in packers:
             if packer == "value" and not issubclass(
-                get_type_origin(type_arg), Collection
+                get_type_origin(_resolve_type_alias_type(type_arg)), Collection
             ):
                 packers.insert(0, packer)
             else:
@@ -359,7 +365,7 @@ def pack_union(
             else:
                 packer_arg_type_check = f"is {packer_arg_type_names[0]}"
             if packer == "value" and not issubclass(
-                packer_arg_type, Collection
+                _resolve_type_alias_type(packer_arg_type), Collection
             ):
                 with lines.indent(
                     f"if value.__class__ {packer_arg_type_check}:"

--- a/mashumaro/core/meta/types/pack.py
+++ b/mashumaro/core/meta/types/pack.py
@@ -350,6 +350,7 @@ def pack_union(
         for packer in packers:
             packer_arg_type_names = []
             for packer_arg_type in packer_arg_types[packer]:
+                packer_arg_type = _resolve_type_alias_type(packer_arg_type)
                 if is_generic(packer_arg_type):
                     packer_arg_type = get_type_origin(packer_arg_type)
                 packer_arg_type_name = clean_id(type_name(packer_arg_type))

--- a/tests/test_pep_695.py
+++ b/tests/test_pep_695.py
@@ -16,6 +16,8 @@ from tests.entities_pep_695 import (
     GenericPassthroughSerializable,
 )
 
+type ScalarAlias = int
+
 
 def test_type_alias_type_with_dataclass_dict_mixin():
     type MyDate = date
@@ -37,6 +39,15 @@ def test_type_alias_type_with_codecs():
     obj = date(2024, 4, 15)
     assert decoder.decode("2024-04-15") == obj
     assert encoder.encode(obj) == "2024-04-15"
+
+
+def test_type_alias_type_with_union_value_packer():
+    @dataclass
+    class MyClass(DataClassDictMixin):
+        x: ScalarAlias | list[int]
+
+    assert MyClass(1).to_dict() == {"x": 1}
+    assert MyClass([1, 2]).to_dict() == {"x": [1, 2]}
 
 
 @pytest.mark.parametrize("deferred_ann", [False, True])


### PR DESCRIPTION
PEP 695 type aliases nested inside unions crash serializer generation
because `pack_union` passes TypeAliasType objects directly to
`issubclass(get_type_origin(...), Collection)`.  

On Python 3.13+, `get_type_origin` returns `None` for TypeAliasType,
and `issubclass()` fails. On 3.12, it returns the alias itself, which
also fails the check.

This adds a helper that recursively unwraps TypeAliasType via
`\_\_value\_\_` before the `issubclass` calls, fixing both the eager
and lazy compilation paths.