### PR TITLE
Add YAMLRocks support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Table of contents
         * [json library](#json-library)
         * [orjson library](#orjson-library)
     * [YAML](#yaml)
+        * [pyyaml library](#pyyaml-library)
+        * [YAMLRocks library](#yamlrocks-library)
     * [TOML](#toml)
     * [MessagePack](#messagepack)
 * [Customization](#customization)
@@ -68,6 +70,7 @@ Table of contents
         * [`allow_postponed_evaluation` config option](#allow_postponed_evaluation-config-option)
         * [`dialect` config option](#dialect-config-option)
         * [`orjson_options` config option](#orjson_options-config-option)
+        * [`yamlrocks_loads_options` and `yamlrocks_dumps_options` config options](#yamlrocks_loads_options-and-yamlrocks_dumps_options-config-options)
         * [`discriminator` config option](#discriminator-config-option)
         * [`lazy_compilation` config option](#lazy_compilation-config-option)
         * [`sort_keys` config option](#sort_keys-config-option)
@@ -608,9 +611,14 @@ MyModel(...).to_jsonb()
 ### YAML
 
 [YAML](https://yaml.org) is a human-friendly data serialization language for
-all programming languages. In order to use this format, the
-[`pyyaml`](https://pypi.org/project/PyYAML/) package must be installed.
-You can install it manually or using an extra option for `mashumaro`:
+all programming languages. mashumaro can produce and consume YAML through
+either the [`pyyaml`](https://pypi.org/project/PyYAML/) library or the
+faster, Rust-backed [YAMLRocks](https://yaml.rocks/) library.
+
+#### pyyaml library
+
+In order to use the [`pyyaml`](https://pypi.org/project/PyYAML/) package, it
+must be installed manually or using an extra option for `mashumaro`:
 
 ```shell
 pip install mashumaro[yaml]
@@ -653,6 +661,98 @@ class MyModel(DataClassYAMLMixin):
 
 MyModel.from_yaml(...)
 MyModel(...).to_yaml()
+```
+
+#### YAMLRocks library
+
+[YAMLRocks](https://yaml.rocks/) is a Rust-backed YAML 1.2 library that is
+faster than `pyyaml`. In order to use it, it must be installed manually or
+using an extra option for `mashumaro`:
+
+```shell
+pip install mashumaro[yamlrocks]
+```
+
+The following data types will be handled by
+[YAMLRocks](https://yaml.rocks/) by default:
+* [`datetime`](https://docs.python.org/3/library/datetime.html#datetime.datetime)
+* [`date`](https://docs.python.org/3/library/datetime.html#datetime.date)
+* [`time`](https://docs.python.org/3/library/datetime.html#datetime.time)
+* [`uuid.UUID`](https://docs.python.org/3/library/uuid.html#uuid.UUID)
+
+YAMLRocks encodes to `bytes`. As with `DataClassORJSONMixin`, `to_yaml`
+returns a decoded `str` (so it stays a drop-in for `DataClassYAMLMixin`),
+while `to_yamlb` returns the raw `bytes`. `from_yaml` accepts both `str`
+and `bytes`.
+
+Efficient decoder and encoder can be used as follows:
+```python
+from mashumaro.codecs.yamlrocks import YAMLRocksDecoder, YAMLRocksEncoder
+
+decoder = YAMLRocksDecoder(<shape_type>, ...)
+decoder.decode(...)
+
+encoder = YAMLRocksEncoder(<shape_type>, ...)
+encoder.encode(...)
+```
+
+Convenient functions can be used as follows:
+```python
+from mashumaro.codecs.yamlrocks import yaml_decode, yaml_encode
+
+yaml_decode(..., <shape_type>)
+yaml_encode(..., <shape_type>)
+```
+
+Convenient function aliases are recommended to be used as follows:
+```python
+import mashumaro.codecs.yamlrocks as yaml_codec
+
+yaml_codec.decode(...<shape_type>)
+yaml_codec.encode(..., <shape_type>)
+```
+
+Mixin can be used as follows:
+```python
+from mashumaro.mixins.yamlrocks import DataClassYAMLRocksMixin
+
+@dataclass
+class MyModel(DataClassYAMLRocksMixin):
+    ...
+
+MyModel.from_yaml(...)
+MyModel(...).to_yaml()   # str
+MyModel(...).to_yamlb()  # bytes
+```
+
+YAMLRocks parses YAML 1.2 by default, where scalars such as `yes`, `no`,
+`on` and `off` stay strings. If you need YAML 1.1 semantics (for example to
+read documents written for `pyyaml`), set the
+[`yamlrocks_loads_options`](#yamlrocks_loads_options-and-yamlrocks_dumps_options-config-options)
+config option. The full list of options is documented in the
+[YAMLRocks options reference](https://yaml.rocks/reference/options/):
+
+```python
+import yamlrocks
+from mashumaro.config import BaseConfig
+
+@dataclass
+class MyModel(DataClassYAMLRocksMixin):
+    class Config(BaseConfig):
+        yamlrocks_loads_options = yamlrocks.OPT_YAML_1_1
+```
+
+With the codec, pass `pre_decoder_func` for decoding and `post_encoder_func`
+for encoding instead:
+
+```python
+import yamlrocks
+from mashumaro.codecs.yamlrocks import YAMLRocksDecoder
+
+decoder = YAMLRocksDecoder(
+    <shape_type>,
+    pre_decoder_func=lambda d: yamlrocks.loads(d, option=yamlrocks.OPT_YAML_1_1),
+)
 ```
 
 ### TOML
@@ -1706,6 +1806,36 @@ class MyClass(DataClassORJSONMixin):
 assert MyClass({1: 2}).to_json() == {"1": 2}
 ```
 
+#### `yamlrocks_loads_options` and `yamlrocks_dumps_options` config options
+
+These options change the default options passed to the `yamlrocks.loads`
+decoder and the `yamlrocks.dumps` encoder used in
+[`DataClassYAMLRocksMixin`](#yamlrocks-library). `yamlrocks_loads_options`
+applies on `from_yaml` (for example to parse YAML 1.1), and
+`yamlrocks_dumps_options` applies on `to_yaml`/`to_yamlb` (for example to sort
+mapping keys). The full list of options is documented in the
+[YAMLRocks options reference](https://yaml.rocks/reference/options/).
+
+```python
+import yamlrocks
+from dataclasses import dataclass
+from mashumaro.config import BaseConfig
+from mashumaro.mixins.yamlrocks import DataClassYAMLRocksMixin
+
+@dataclass
+class MyClass(DataClassYAMLRocksMixin):
+    b: str
+    a: str
+
+    class Config(BaseConfig):
+        yamlrocks_loads_options = yamlrocks.OPT_YAML_1_1
+        yamlrocks_dumps_options = yamlrocks.OPT_SORT_KEYS
+
+# loads parses YAML 1.1 (yes -> True), dumps sorts keys
+assert MyClass.from_yaml("b: yes\na: no") == MyClass("True", "False")
+assert MyClass("x", "y").to_yaml() == "a: y\nb: x\n"
+```
+
 #### `discriminator` config option
 
 This option is described in the
@@ -2103,6 +2233,7 @@ assert data["simple_set"] is obj.simple_set
 This option is enabled for `list` and `dict` in the default dialects that
 belong to mixins and codecs for the following formats:
 * [JSON (orjson library)](#orjson-library)
+* [YAML (YAMLRocks library)](#yamlrocks-library)
 * [TOML](#toml)
 * [MessagePack](#messagepack)
 

--- a/mashumaro/codecs/yamlrocks.py
+++ b/mashumaro/codecs/yamlrocks.py
@@ -1,0 +1,116 @@
+from collections.abc import Callable
+from typing import Any, Generic, Type, TypeVar, final, overload
+
+import yamlrocks
+
+from mashumaro.codecs._builder import CodecCodeBuilder
+from mashumaro.core.meta.helpers import get_args
+from mashumaro.dialect import Dialect
+from mashumaro.mixins.yamlrocks import YAMLRocksDialect
+
+T = TypeVar("T")
+
+
+EncodedData = str | bytes
+PreDecoderFunc = Callable[[EncodedData], Any]
+PostEncoderFunc = Callable[[Any], bytes]
+
+
+class YAMLRocksDecoder(Generic[T]):
+    @overload
+    def __init__(
+        self,
+        shape_type: Type[T],
+        *,
+        default_dialect: Type[Dialect] | None = None,
+        pre_decoder_func: PreDecoderFunc = yamlrocks.loads,
+    ): ...
+
+    @overload
+    def __init__(
+        self,
+        shape_type: Any,
+        *,
+        default_dialect: Type[Dialect] | None = None,
+        pre_decoder_func: PreDecoderFunc = yamlrocks.loads,
+    ): ...
+
+    def __init__(
+        self,
+        shape_type: Type[T] | Any,
+        *,
+        default_dialect: Type[Dialect] | None = None,
+        pre_decoder_func: PreDecoderFunc = yamlrocks.loads,
+    ):
+        if default_dialect is not None:
+            default_dialect = YAMLRocksDialect.merge(default_dialect)
+        else:
+            default_dialect = YAMLRocksDialect
+        code_builder = CodecCodeBuilder.new(
+            type_args=get_args(shape_type), default_dialect=default_dialect
+        )
+        code_builder.add_decode_method(shape_type, self, pre_decoder_func)
+
+    @final
+    def decode(self, data: EncodedData) -> T: ...
+
+
+class YAMLRocksEncoder(Generic[T]):
+    @overload
+    def __init__(
+        self,
+        shape_type: Type[T],
+        *,
+        default_dialect: Type[Dialect] | None = None,
+        post_encoder_func: PostEncoderFunc = yamlrocks.dumps,
+    ): ...
+
+    @overload
+    def __init__(
+        self,
+        shape_type: Any,
+        *,
+        default_dialect: Type[Dialect] | None = None,
+        post_encoder_func: PostEncoderFunc = yamlrocks.dumps,
+    ): ...
+
+    def __init__(
+        self,
+        shape_type: Type[T] | Any,
+        *,
+        default_dialect: Type[Dialect] | None = None,
+        post_encoder_func: PostEncoderFunc = yamlrocks.dumps,
+    ):
+        if default_dialect is not None:
+            default_dialect = YAMLRocksDialect.merge(default_dialect)
+        else:
+            default_dialect = YAMLRocksDialect
+        code_builder = CodecCodeBuilder.new(
+            type_args=get_args(shape_type), default_dialect=default_dialect
+        )
+        code_builder.add_encode_method(shape_type, self, post_encoder_func)
+
+    @final
+    def encode(self, obj: T) -> bytes: ...
+
+
+def yaml_decode(data: EncodedData, shape_type: Type[T]) -> T:
+    return YAMLRocksDecoder(shape_type).decode(data)
+
+
+def yaml_encode(obj: T, shape_type: Type[T] | Any) -> bytes:
+    return YAMLRocksEncoder(shape_type).encode(obj)
+
+
+decode = yaml_decode
+encode = yaml_encode
+
+
+__all__ = [
+    "YAMLRocksDecoder",
+    "YAMLRocksEncoder",
+    "yaml_decode",
+    "yaml_encode",
+    "decode",
+    "encode",
+]

--- a/mashumaro/config.py
+++ b/mashumaro/config.py
@@ -51,6 +51,8 @@ class BaseConfig:
     omit_none: bool | Literal[Sentinel.MISSING] = Sentinel.MISSING
     omit_default: bool | Literal[Sentinel.MISSING] = Sentinel.MISSING
     orjson_options: int | None = 0
+    yamlrocks_loads_options: int | None = 0
+    yamlrocks_dumps_options: int | None = 0
     json_schema: dict[str, Any] = {}
     discriminator: Discriminator | None = None
     lazy_compilation: bool = False

--- a/mashumaro/core/meta/code/builder.py
+++ b/mashumaro/core/meta/code/builder.py
@@ -116,6 +116,7 @@ class CodeBuilder:
         allow_postponed_evaluation: bool = True,
         format_name: str = "dict",
         decoder: typing.Any | None = None,
+        decoder_kwargs: dict[str, typing.Any] | None = None,
         encoder: typing.Any | None = None,
         encoder_kwargs: dict[str, typing.Any] | None = None,
         default_dialect: typing.Type[Dialect] | None = None,
@@ -140,6 +141,7 @@ class CodeBuilder:
         self.allow_postponed_evaluation = allow_postponed_evaluation
         self.format_name = format_name
         self.decoder = decoder
+        self.decoder_kwargs = decoder_kwargs or {}
         self.encoder = encoder
         self.encoder_kwargs = encoder_kwargs or {}
 
@@ -338,6 +340,7 @@ class CodeBuilder:
             f"allow_postponed_evaluation=False,"
             f"format_name='{self.format_name}',"
             f"decoder={type_name(self.decoder)},"
+            f"decoder_kwargs={self._get_decoder_kwargs()},"
             f"default_dialect={type_name(self.default_dialect)}"
             f").add_unpack_method()"
         )
@@ -365,7 +368,7 @@ class CodeBuilder:
             self._add_unpack_method_lines_lazy(method_name)
         else:
             if self.decoder is not None:
-                self.add_line("d = decoder(d)")
+                self.add_line(self._decoder_call_line())
             discr = self.get_discriminator()
             if discr:
                 if not discr.include_subtypes:
@@ -513,9 +516,17 @@ class CodeBuilder:
             else:
                 self.add_line(f"return {cls_inst}")
 
+    def _decoder_call_line(self) -> str:
+        if self.decoder_kwargs:
+            decoder_options = ", ".join(
+                f"{k}={v[0]}" for k, v in self.decoder_kwargs.items()
+            )
+            return f"d = decoder(d, {decoder_options})"
+        return "d = decoder(d)"
+
     def _add_unpack_method_with_dialect_lines(self, method_name: str) -> None:
         if self.decoder is not None:
-            self.add_line("d = decoder(d)")
+            self.add_line(self._decoder_call_line())
         unpacker_args = ", ".join(
             filter(None, ("cls", "d", self.get_unpack_method_flags()))
         )
@@ -639,6 +650,8 @@ class CodeBuilder:
         pluggable_flags = []
         if pass_decoder and self.decoder is not None:
             pluggable_flags.append("decoder=decoder")
+            for value in self._get_decoder_kwargs(cls).values():
+                pluggable_flags.append(f"{value[0]}={value[0]}")
         for option, flag in ((ADD_DIALECT_SUPPORT, "dialect"),):
             if self.is_code_generation_option_enabled(option, cls):
                 if self.is_code_generation_option_enabled(option):
@@ -716,6 +729,9 @@ class CodeBuilder:
         if pass_decoder and self.decoder is not None:
             pos_param_names.append("decoder")
             pos_param_values.append(type_name(self.decoder))
+            for value in self._get_decoder_kwargs().values():
+                kw_param_names.append(value[0])
+                kw_param_values.append(value[1])
 
         kw_param_names.append("dialect")
         kw_param_values.append("None")
@@ -1072,6 +1088,20 @@ class CodeBuilder:
             if isinstance(packer_value, ConfigValue):
                 packer_value = getattr(self.get_config(cls), packer_value.name)
             result[encoder_param] = (packer_param, packer_value)
+        return result
+
+    def _get_decoder_kwargs(
+        self, cls: typing.Type | None = None
+    ) -> dict[str, typing.Any]:
+        result = {}
+        for decoder_param, value in self.decoder_kwargs.items():
+            unpacker_param = value[0]
+            unpacker_value = value[1]
+            if isinstance(unpacker_value, ConfigValue):
+                unpacker_value = getattr(
+                    self.get_config(cls), unpacker_value.name
+                )
+            result[decoder_param] = (unpacker_param, unpacker_value)
         return result
 
     def _add_pack_method_definition(self, method_name: str) -> None:

--- a/mashumaro/core/meta/mixin.py
+++ b/mashumaro/core/meta/mixin.py
@@ -34,11 +34,13 @@ def compile_mixin_unpacker(
     format_name: str = "dict",
     dialect: Type[Dialect] | None = None,
     decoder: Any = None,
+    decoder_kwargs: dict[str, dict[str, tuple[str, Any]]] | None = None,
 ) -> None:
     builder = CodeBuilder(
         cls=cls,
         format_name=format_name,
         decoder=decoder,
+        decoder_kwargs=decoder_kwargs,
         default_dialect=dialect,
     )
     config = builder.get_config()

--- a/mashumaro/mixins/yamlrocks.py
+++ b/mashumaro/mixins/yamlrocks.py
@@ -1,0 +1,82 @@
+from collections.abc import Callable
+from datetime import date, datetime, time
+from typing import Any, Type, TypeVar, final
+from uuid import UUID
+
+import yamlrocks
+
+from mashumaro.core.helpers import ConfigValue
+from mashumaro.dialect import Dialect
+from mashumaro.helper import pass_through
+from mashumaro.mixins.dict import DataClassDictMixin
+
+T = TypeVar("T", bound="DataClassYAMLRocksMixin")
+
+
+EncodedData = str | bytes
+Encoder = Callable[[Any], bytes]
+# yamlrocks.loads is precisely typed and returns a broad union, so the
+# decoder alias stays Any rather than narrowing to dict.
+Decoder = Callable[[EncodedData], Any]
+
+
+class YAMLRocksDialect(Dialect):
+    no_copy_collections = (list, dict)
+    serialization_strategy = {
+        datetime: {"serialize": pass_through},
+        date: {"serialize": pass_through},
+        time: {"serialize": pass_through},
+        UUID: {"serialize": pass_through},
+    }
+
+
+class DataClassYAMLRocksMixin(DataClassDictMixin):
+    __slots__ = ()
+
+    __mashumaro_builder_params = {
+        "packer": {
+            "format_name": "yamlb",
+            "dialect": YAMLRocksDialect,
+            "encoder": yamlrocks.dumps,
+            "encoder_kwargs": {
+                "option": (
+                    "yamlrocks_dumps_options",
+                    ConfigValue("yamlrocks_dumps_options"),
+                )
+            },
+        },
+        "unpacker": {
+            "format_name": "yaml",
+            "dialect": YAMLRocksDialect,
+            "decoder": yamlrocks.loads,
+            "decoder_kwargs": {
+                "option": (
+                    "yamlrocks_loads_options",
+                    ConfigValue("yamlrocks_loads_options"),
+                )
+            },
+        },
+    }
+
+    @final
+    def to_yamlb(
+        self: T,
+        encoder: Encoder = yamlrocks.dumps,
+        *,
+        yamlrocks_dumps_options: int = ...,
+        **to_dict_kwargs: Any,
+    ) -> bytes: ...
+
+    def to_yaml(self: T, **kwargs: Any) -> str:
+        return self.to_yamlb(**kwargs).decode()
+
+    @classmethod
+    @final
+    def from_yaml(
+        cls: Type[T],
+        data: EncodedData,
+        decoder: Decoder = yamlrocks.loads,
+        *,
+        yamlrocks_loads_options: int = ...,
+        **from_dict_kwargs: Any,
+    ) -> T: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ Repository = "https://github.com/Fatal1ty/mashumaro"
 orjson = ["orjson"]
 msgpack = ["msgpack>=0.5.6"]
 yaml = ["pyyaml>=3.13"]
+yamlrocks = ["yamlrocks"]
 toml = [
     "tomli-w>=1.0",
     "tomli>=1.1.0;python_version<'3.11'",
@@ -57,6 +58,7 @@ module = [
     'mashumaro.mixins.dict',
     'mashumaro.mixins.msgpack',
     'mashumaro.mixins.toml',
+    'mashumaro.mixins.yamlrocks',
     'mashumaro.codecs.*',
 ]
 disable_error_code = 'empty-body'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ pyyaml>=3.13
 tomli-w>=1.0
 tomli>=1.1.0;python_version<'3.11'
 orjson>=3.10.10
+yamlrocks>=0.2.1
 
 # tests
 mypy>=2.0

--- a/tests/test_codecs/test_yamlrocks_codec.py
+++ b/tests/test_codecs/test_yamlrocks_codec.py
@@ -1,0 +1,73 @@
+from datetime import date
+from typing import Dict, List
+
+import yamlrocks
+
+from mashumaro.codecs.yamlrocks import (
+    YAMLRocksDecoder,
+    YAMLRocksEncoder,
+    yaml_decode,
+    yaml_encode,
+)
+from mashumaro.dialect import Dialect
+
+
+class MyDialect(Dialect):
+    serialization_strategy = {
+        date: {"serialize": date.toordinal, "deserialize": date.fromordinal}
+    }
+
+
+def test_yaml_decode():
+    data = yamlrocks.dumps(["2023-09-22", "2023-09-23"])
+    assert yaml_decode(data, List[date]) == [
+        date(2023, 9, 22),
+        date(2023, 9, 23),
+    ]
+
+
+def test_yaml_encode():
+    assert yaml_encode(
+        [date(2023, 9, 22), date(2023, 9, 23)], List[date]
+    ) == yamlrocks.dumps([date(2023, 9, 22), date(2023, 9, 23)])
+
+
+def test_decoder_with_default_dialect():
+    decoder = YAMLRocksDecoder(List[date], default_dialect=MyDialect)
+    assert decoder.decode(yamlrocks.dumps([738785, 738786])) == [
+        date(2023, 9, 22),
+        date(2023, 9, 23),
+    ]
+
+
+def test_encoder_with_default_dialect():
+    encoder = YAMLRocksEncoder(List[date], default_dialect=MyDialect)
+    assert encoder.encode(
+        [date(2023, 9, 22), date(2023, 9, 23)]
+    ) == yamlrocks.dumps([738785, 738786])
+
+
+def test_decoder_with_yaml_1_1_via_pre_decoder_func():
+    # By default yamlrocks parses YAML 1.2, where "yes" is a string. A custom
+    # pre_decoder_func lets callers opt into YAML 1.1, where it is a bool.
+    assert yaml_decode("x: yes", Dict[str, str]) == {"x": "yes"}
+
+    decoder = YAMLRocksDecoder(
+        Dict[str, bool],
+        pre_decoder_func=lambda d: yamlrocks.loads(
+            d, option=yamlrocks.OPT_YAML_1_1
+        ),
+    )
+    assert decoder.decode("x: yes") == {"x": True}
+
+
+def test_encoder_with_post_encoder_func():
+    encoder = YAMLRocksEncoder(
+        List[int],
+        post_encoder_func=lambda obj: yamlrocks.dumps(
+            obj, option=yamlrocks.OPT_SORT_KEYS
+        ),
+    )
+    assert encoder.encode([1, 2]) == yamlrocks.dumps(
+        [1, 2], option=yamlrocks.OPT_SORT_KEYS
+    )

--- a/tests/test_yamlrocks.py
+++ b/tests/test_yamlrocks.py
@@ -1,0 +1,183 @@
+from dataclasses import dataclass
+from datetime import date, datetime, time
+from typing import List
+from uuid import UUID, uuid4
+
+import yamlrocks
+
+from mashumaro import DataClassDictMixin
+from mashumaro.config import BaseConfig
+from mashumaro.dialect import Dialect
+from mashumaro.mixins.yamlrocks import DataClassYAMLRocksMixin
+
+serialization_strategy = {
+    datetime: {
+        "serialize": lambda dt: dt.strftime("%Y/%m/%d/%H/%M/%S"),
+        "deserialize": lambda s: datetime.strptime(s, "%Y/%m/%d/%H/%M/%S"),
+    },
+    date: {"serialize": date.toordinal, "deserialize": date.fromordinal},
+    time: {
+        "serialize": lambda t: t.strftime("%H/%M/%S"),
+        "deserialize": lambda s: datetime.strptime(s, "%H/%M/%S").time(),
+    },
+    UUID: {
+        "serialize": lambda x: f"uuid:{x}",
+        "deserialize": lambda s: UUID(s[5:]),
+    },
+}
+
+
+class MyDialect(Dialect):
+    serialization_strategy = serialization_strategy
+
+
+@dataclass
+class InnerDataClass(DataClassDictMixin):
+    x: str
+
+
+@dataclass
+class DataClass(DataClassYAMLRocksMixin):
+    x: str
+    inner: InnerDataClass
+
+
+def test_to_yaml():
+    @dataclass
+    class DataClass(DataClassYAMLRocksMixin):
+        x: List[int]
+
+    dumped = yamlrocks.dumps({"x": [1, 2, 3]})
+    # to_yamlb returns the raw yamlrocks bytes; to_yaml decodes them to str
+    assert DataClass([1, 2, 3]).to_yamlb() == dumped
+    assert DataClass([1, 2, 3]).to_yaml() == dumped.decode()
+
+
+def test_from_yaml():
+    @dataclass
+    class DataClass(DataClassYAMLRocksMixin):
+        x: List[int]
+
+    dumped = yamlrocks.dumps({"x": [1, 2, 3]})
+    assert DataClass.from_yaml(dumped) == DataClass([1, 2, 3])
+    # str input is accepted as well as bytes
+    assert DataClass.from_yaml(dumped.decode()) == DataClass([1, 2, 3])
+
+
+def test_yamlrocks_nested_roundtrip():
+    instance = DataClass("a", InnerDataClass("b"))
+    assert DataClass.from_yaml(instance.to_yaml()) == instance
+
+
+def test_yamlrocks_native_types_passed_through():
+    # datetime/date/time/UUID are serialized by yamlrocks itself, so the
+    # encoded form matches what yamlrocks produces for the raw values.
+    @dataclass
+    class DataClass(DataClassYAMLRocksMixin):
+        dt: datetime
+        d: date
+        t: time
+        uid: UUID
+
+    _dt = datetime(2022, 10, 12, 12, 54, 30)
+    _d = date(2022, 10, 12)
+    _t = time(12, 54, 30)
+    _uid = uuid4()
+    instance = DataClass(_dt, _d, _t, _uid)
+    expected = yamlrocks.dumps({"dt": _dt, "d": _d, "t": _t, "uid": _uid})
+    assert instance.to_yamlb() == expected
+    assert DataClass.from_yaml(instance.to_yamlb()) == instance
+
+
+def test_yamlrocks_with_serialization_strategy():
+    @dataclass
+    class DataClass(DataClassYAMLRocksMixin):
+        datetime: List[datetime]
+        date: List[date]
+        time: List[time]
+        uuid: List[UUID]
+
+        class Config(BaseConfig):
+            serialization_strategy = serialization_strategy
+
+    _datetime = datetime(2022, 10, 12, 12, 54, 30)
+    _date = date(2022, 10, 12)
+    _time = time(12, 54, 30)
+    _uuid = uuid4()
+    dict_dumped = {
+        "datetime": [_datetime.strftime("%Y/%m/%d/%H/%M/%S")],
+        "date": [_date.toordinal()],
+        "time": [_time.strftime("%H/%M/%S")],
+        "uuid": [f"uuid:{_uuid}"],
+    }
+    instance = DataClass([_datetime], [_date], [_time], [_uuid])
+    assert instance.to_dict() == dict_dumped
+    assert instance.to_yamlb() == yamlrocks.dumps(dict_dumped)
+    assert DataClass.from_yaml(yamlrocks.dumps(dict_dumped)) == instance
+
+
+def test_yamlrocks_dumps_options_sort_keys():
+    @dataclass
+    class DataClass(DataClassYAMLRocksMixin):
+        class Config(BaseConfig):
+            yamlrocks_dumps_options = yamlrocks.OPT_SORT_KEYS
+
+        b: int
+        a: int
+
+    assert DataClass(1, 2).to_yamlb() == yamlrocks.dumps(
+        {"b": 1, "a": 2}, option=yamlrocks.OPT_SORT_KEYS
+    )
+
+
+def test_yamlrocks_loads_options_yaml_1_1():
+    # Default parsing is YAML 1.2, where "yes" stays a string. The loads
+    # option lets the mixin opt into YAML 1.1, where it becomes a bool.
+    @dataclass
+    class Default(DataClassYAMLRocksMixin):
+        x: str
+
+    @dataclass
+    class Yaml11(DataClassYAMLRocksMixin):
+        class Config(BaseConfig):
+            yamlrocks_loads_options = yamlrocks.OPT_YAML_1_1
+
+        x: str
+
+    assert Default.from_yaml("x: yes").x == "yes"
+    assert Yaml11.from_yaml("x: yes").x == "True"
+
+
+def test_yamlrocks_options_survive_lazy_compilation():
+    # Lazy compilation rebuilds the unpacker/packer on first use; the loads
+    # and dumps options must be threaded through that rebuild.
+    @dataclass
+    class DataClass(DataClassYAMLRocksMixin):
+        class Config(BaseConfig):
+            lazy_compilation = True
+            yamlrocks_loads_options = yamlrocks.OPT_YAML_1_1
+            yamlrocks_dumps_options = yamlrocks.OPT_SORT_KEYS
+
+        b: str
+        a: str
+
+    assert DataClass.from_yaml("b: yes\na: no") == DataClass("True", "False")
+    assert DataClass("x", "y").to_yamlb() == yamlrocks.dumps(
+        {"b": "x", "a": "y"}, option=yamlrocks.OPT_SORT_KEYS
+    )
+
+
+def test_yamlrocks_loads_and_dumps_options_together():
+    @dataclass
+    class DataClass(DataClassYAMLRocksMixin):
+        class Config(BaseConfig):
+            yamlrocks_loads_options = yamlrocks.OPT_YAML_1_1
+            yamlrocks_dumps_options = yamlrocks.OPT_SORT_KEYS
+
+        b: str
+        a: str
+
+    assert DataClass.from_yaml("b: yes\na: no") == DataClass("True", "False")
+    assert DataClass("x", "y").to_yamlb() == yamlrocks.dumps(
+        {"b": "x", "a": "y"}, option=yamlrocks.OPT_SORT_KEYS
+    )


### PR DESCRIPTION
Adds [YAMLRocks](https://yaml.rocks/) as a YAML backend, alongside the existing `pyyaml` integration, wired up the same way as the `orjson` and `toml` backends: a mixin plus a codec, behind an optional extra.

[YAMLRocks](https://yaml.rocks/) is a Rust-backed YAML library that is a strong fit as a backend here:

- Roughly 5 to 10x faster parsing and 15 to 19x faster dumping than PyYAML's C loader, which is the relevant comparison since mashumaro's `pyyaml` integration already defaults to `CSafeLoader` / `CDumper`.
- A custom YAML 1.2 scanner and parser that passes the full official YAML test suite, with a YAML 1.1 compatibility mode for legacy documents.
- Secure by default: no code execution from tags, and hardened against alias bombs and deeply nested input.
- Validated against thousands of real-world configurations across many ecosystems (Home Assistant, Kubernetes, Docker Compose, Ansible, and more).

### What's included

- `mashumaro.mixins.yamlrocks.DataClassYAMLRocksMixin` with `from_yaml` / `to_yaml` / `to_yamlb`, plus a `YAMLRocksDialect`.
- `mashumaro.codecs.yamlrocks` with `YAMLRocksDecoder` / `YAMLRocksEncoder` and the `yaml_decode` / `yaml_encode` / `decode` / `encode` helpers.
- A `yamlrocks` optional dependency (`pip install mashumaro[yamlrocks]`).
- Tests and README docs.

`datetime`, `date`, `time` and `uuid.UUID` are passed through to YAMLRocks' native serialization (via the dialect), mirroring `OrjsonDialect`. `no_copy_collections` is enabled for `list` and `dict` as well.

### bytes vs str

YAMLRocks encodes to `bytes`. Following the `orjson` mixin's `to_jsonb` / `to_json` split, `to_yamlb` returns the raw `bytes` and `to_yaml` returns a decoded `str`, so `DataClassYAMLRocksMixin` stays a drop-in for `DataClassYAMLMixin`. `from_yaml` accepts both `str` and `bytes`.

### Configurable options (loads and dumps)

`orjson` exposes a single `orjson_options` for the encoder. YAMLRocks has meaningful options on both sides (for example YAML 1.1 parsing on load, key sorting on dump), so this adds two config options: `yamlrocks_loads_options` and `yamlrocks_dumps_options`. See the [options reference](https://yaml.rocks/reference/options/).

To support the load side, this introduces a `decoder_kwargs` mechanism in the core, parallel to the existing `encoder_kwargs`. The codegen was already asymmetric (the packer had `encoder_kwargs`, the unpacker had nothing), and the option must be config driven and resolved per class at code-generation time via `ConfigValue`, so a static wrapper around `loads` would not do. `decoder_kwargs` fills that gap symmetrically and is threaded through the same paths as `encoder_kwargs`, including lazy compilation and dialect dispatch. It is gated entirely behind a non-empty `decoder_kwargs`, so generated code for every other loader (`from_dict`, orjson, toml, msgpack) is byte-for-byte unchanged and there is no runtime impact on them.

../Frenck

<p>
  <a href="https://www.linkedin.com/in/frenck/"><img src="https://github.com/frenck/frenck/raw/main/images/linkedin.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://youtube.com/@frenck"><img src="https://github.com/frenck/frenck/raw/main/images/youtube.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://bsky.app/profile/frenck.social"><img src="https://github.com/frenck/frenck/raw/main/images/bluesky.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://fosstodon.org/@frenck"><img src="https://github.com/frenck/frenck/raw/main/images/mastodon.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.instagram.com/frenck/"><img src="https://github.com/frenck/frenck/raw/main/images/instagram.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.threads.net/@frenck"><img src="https://github.com/frenck/frenck/raw/main/images/threads.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.facebook.com/frenck.dev/"><img src="https://github.com/frenck/frenck/raw/main/images/facebook.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://x.com/frenck"><img src="https://github.com/frenck/frenck/raw/main/images/x.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.tiktok.com/@frenck.nl"><img src="https://github.com/frenck/frenck/raw/main/images/tiktok.svg" width="18" height="18"></a>
</p>

Blogging my personal ramblings at <a href="https://frenck.dev">frenck.dev</a>
