### PR TITLE
Honor NamedTuple defaults with namedtuple_as_dict when a key is omitted

### DIFF
--- a/mashumaro/core/meta/types/unpack.py
+++ b/mashumaro/core/meta/types/unpack.py
@@ -1134,7 +1134,7 @@ def unpack_named_tuple(spec: ValueSpec) -> Expression:
         with lines.indent("try:"):
             for unpacker in unpackers:
                 lines.append(f"fields.append({unpacker})")
-        with lines.indent("except IndexError:"):
+        with lines.indent("except (IndexError, KeyError):"):
             lines.append("pass")
         field_type = spec.builder.get_type_name_identifier(spec.type)
         lines.append(f"return {field_type}(*fields)")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -204,6 +204,24 @@ def test_untyped_named_tuple_with_defaults_as_dict():
     assert DataClass.from_dict({"munpwd": {"i": 1, "f": 2.0}}) == obj
 
 
+def test_named_tuple_as_dict_with_missing_default_key():
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        mnpwd: MyNamedTupleWithDefaults
+        munpwd: MyUntypedNamedTupleWithDefaults
+
+        class Config(BaseConfig):
+            namedtuple_as_dict = True
+
+    # Omitting a key that has a default should fall back to that default,
+    # the same way an omitted trailing element does for the as_list engine.
+    obj = DataClass(
+        mnpwd=MyNamedTupleWithDefaults(i=1),
+        munpwd=MyUntypedNamedTupleWithDefaults(i=1),
+    )
+    assert DataClass.from_dict({"mnpwd": {"i": 1}, "munpwd": {"i": 1}}) == obj
+
+
 def test_named_tuple_as_dict_and_as_list_engine():
     @dataclass
     class DataClass(DataClassDictMixin):


### PR DESCRIPTION
Fixes #341.

With `namedtuple_as_dict = True`, a `NamedTuple` field that has a default cannot be deserialized from a dict that omits that key — it raises `InvalidFieldValue`, even though the default (`as_list`) engine correctly falls back to the default for an omitted trailing element:

```python
ListForm.from_dict({"p": [5]})        # -> Point(x=5, y='default')   OK
DictForm.from_dict({"p": {"x": 5}})   # -> InvalidFieldValue          before this change
```

**Root cause** (`mashumaro/core/meta/types/unpack.py`, `unpack_named_tuple`): when the NamedTuple has defaults, the generated unpacker catches an exception so the NamedTuple's own defaults fill missing values — but it caught only `IndexError` (raised by list access on a short list). Dict access on a missing key raises `KeyError`, which escaped and was wrapped as `InvalidFieldValue`. The as_list behavior is the tested contract (`test_dataclass_with_named_tuple_with_defaults`); the as_dict path was never extended to it.

**Fix**: catch `KeyError` as well.

```python
-        with lines.indent("except IndexError:"):
+        with lines.indent("except (IndexError, KeyError):"):
```

**Verification** (re-runnable from the diff): added `test_named_tuple_as_dict_with_missing_default_key` (using the existing NamedTuple test entities) — it fails on the current tree (`InvalidFieldValue`) and passes with the fix. A missing *non-default* key still errors, and the no-defaults branch is unaffected (it doesn't generate this fallback). Full suite green.

---

*Disclosure*: This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the test, and wrote this description (and the linked issue). The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
