### PR TITLE
Resolve PEP 695 type alias in the union unpacker

### DIFF
--- a/mashumaro/core/meta/types/unpack.py
+++ b/mashumaro/core/meta/types/unpack.py
@@ -60,6 +60,7 @@ from mashumaro.core.meta.helpers import (
     is_unpack,
     iter_all_subclasses,
     not_none_type_arg,
+    resolve_type_alias_type,
     resolve_type_params,
     substitute_type_params,
     type_name,
@@ -207,10 +208,15 @@ class UnionUnpackerBuilder(AbstractUnpackerBuilder):
             unpacker_block = CodeLines()
             if isinstance(unpacker, TypeMatchEligibleExpression):
                 do_try = False
+                # A PEP 695 type alias carries the alias name (e.g.
+                # "ScalarAlias"), which is not bound in the generated code's
+                # namespace; resolve it to the underlying type first, as the
+                # packer side already does.
+                match_type = resolve_type_alias_type(type_arg)
                 if type_match_statements > 1:
-                    condition = f"__value_type is {type_arg.__name__}"
+                    condition = f"__value_type is {match_type.__name__}"
                 else:
-                    condition = f"type(value) is {type_arg.__name__}"
+                    condition = f"type(value) is {match_type.__name__}"
                 if (condition, unpacker) in unpackers:  # pragma: no cover
                     # we shouldn't be here because condition is always unique
                     continue

--- a/tests/test_pep_695.py
+++ b/tests/test_pep_695.py
@@ -50,6 +50,15 @@ def test_type_alias_type_with_union_value_packer():
     assert MyClass([1, 2]).to_dict() == {"x": [1, 2]}
 
 
+def test_type_alias_type_with_union_value_unpacker():
+    @dataclass
+    class MyClass(DataClassDictMixin):
+        x: ScalarAlias | list[int]
+
+    assert MyClass.from_dict({"x": 1}) == MyClass(1)
+    assert MyClass.from_dict({"x": [1, 2]}) == MyClass([1, 2])
+
+
 @pytest.mark.parametrize("deferred_ann", [False, True])
 def test_pep695_generic_serialization_strategy(deferred_ann):
     if deferred_ann:


### PR DESCRIPTION
Fixes #343.

### Problem

A PEP 695 `type` alias used as a member of a union field serializes fine but fails to deserialize — `from_dict` raises `InvalidFieldValue` for **every** value, so the type no longer round-trips:

```python
type ScalarAlias = int

@dataclass
class MyClass(DataClassDictMixin):
    x: "ScalarAlias | list[int]"

MyClass(1).to_dict()             # {'x': 1}   -- ok (fixed in #336)
MyClass.from_dict({"x": 1})      # InvalidFieldValue
MyClass.from_dict({"x": [1, 2]}) # InvalidFieldValue
```

### Cause

`UnionUnpackerBuilder._add_body` builds the type-match condition from the raw member's `__name__`:

```python
condition = f"type(value) is {type_arg.__name__}"
```

For a `TypeAliasType`, `__name__` is the alias name (`"ScalarAlias"`), which is not bound in the generated code's namespace. The emitted line becomes `type(value) is ScalarAlias`, raising `NameError` before any working branch is reached — and since `from_dict` converts exceptions into `InvalidFieldValue`, the alias member breaks the entire union, not just its own branch.

### Fix

Resolve the alias to its underlying type before taking `__name__`, exactly as the packer side already does (`resolve_type_alias_type`, added in #336):

```python
match_type = resolve_type_alias_type(type_arg)
...
condition = f"type(value) is {match_type.__name__}"
```

`resolve_type_alias_type` is a no-op for non-alias types and on Python < 3.12, so this is safe on all supported versions.

### Tests

Added `test_type_alias_type_with_union_value_unpacker` mirroring the existing `..._packer` test but asserting `from_dict`. It fails on `master` (`InvalidFieldValue`) and passes with the fix. The union / PEP 695 / recursive-union / discriminated-union suites pass (161 passed). `black`, `ruff`, and `mypy` are clean on the change.